### PR TITLE
Refactor LOG() into logger.lua.

### DIFF
--- a/scripts/mod_loader/logger.lua
+++ b/scripts/mod_loader/logger.lua
@@ -1,0 +1,63 @@
+local Logger = {
+  LOG_LEVEL_NONE = 0,
+  LOG_LEVEL_CONSOLE = 1,
+  LOG_LEVEL_FILE = 2,
+
+  logLevel = 0,
+  logFile = nil,
+}
+
+function Logger.logNothing()
+  Logger.logLevel = Logger.LOG_LEVEL_NONE
+end
+
+function Logger.logToConsole()
+  Logger.logLevel = Logger.LOG_LEVEL_CONSOLE
+end
+
+function Logger.logToFile(filename)
+  Logger.logLevel = Logger.LOG_LEVEL_FILE
+  Logger.logFile = io.open(filename, "a+")
+
+  local message =
+      string.format("\n===== Logging started at: %s =====\n", os.date("%Y-%m-%d %H:%M:%S"))
+
+  Logger.logFile:write(message)
+  Logger.logFile:flush()
+
+  message = string.format("Logging to file: %s", filename)
+
+  ConsolePrint(message)
+  print(message)
+end
+
+function Logger.log(...)
+  if Logger.logLevel == Logger.LOG_LEVEL_NONE then
+    return
+  end
+
+  for i, v in ipairs(arg) do
+    arg[i] = tostring(v)
+  end
+
+  local message = table.concat(arg, " ")
+  local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+  local info = debug.getinfo(2, "Sl")
+  local caller = string.format("%s %s:%d", timestamp, info.short_src , info.currentline)
+
+  if Logger.logLevel == Logger.LOG_LEVEL_FILE and Logger.logFile ~= nil then
+    Logger.logFile:write(string.format("%s\n%s\n", caller, message))
+    Logger.logFile:flush()
+  end
+
+  ConsolePrint(caller)
+  print(caller)
+
+  ConsolePrint(message)
+  print(message)
+end
+
+-- Override the original LOG(...) function.
+LOG = Logger.log
+
+return Logger


### PR DESCRIPTION
This refactors ITB's LOG() function to support a) logging to a file and b) not logging anything at all (by default).

With this change, modders can make liberal use of the LOG() function during development and not have to change anything for release.

mod_loader.lua will need to add in the line at the top of its init() function:

`Logger = require("scripts/mod_loader/logger")`

This can then be used in any mod's init.lua file to write to file and console:

`Logger.logToFile("logging.txt")`

Or to enable the standard console only:

`Logger.logToConsole()`