### PR TITLE
Improvement to GetCurrentMission

### DIFF
--- a/scripts/mod_loader/altered/misc.lua
+++ b/scripts/mod_loader/altered/misc.lua
@@ -78,6 +78,14 @@ local function overrideNextPhase()
 	end
 end
 
+local function updateCurrentMission()
+	local region = GetCurrentRegion()
+	
+	if region then
+		modApi.current_mission = GAME:GetMission(region.mission)
+	end
+end
+
 local oldStartNewGame = startNewGame
 function startNewGame()
 	Settings = modApi:loadSettings()
@@ -147,6 +155,7 @@ function LoadGame()
 
 	RestoreGameVariables(Settings)
 	overrideNextPhase()
+	updateCurrentMission()
 
 	if GAME.CustomDifficulty then
 		SetDifficulty(GAME.CustomDifficulty)

--- a/scripts/mod_loader/altered/missions.lua
+++ b/scripts/mod_loader/altered/missions.lua
@@ -56,6 +56,7 @@ end
 
 local oldBaseUpdate = Mission.BaseUpdate
 function Mission:BaseUpdate()
+	modApi.current_mission = self
 	modApi:processRunLaterQueue(self)
 
 	oldBaseUpdate(self)
@@ -72,6 +73,7 @@ end
 
 local oldBaseDeployment = Mission.BaseDeployment
 function Mission:BaseDeployment()
+	modApi.current_mission = self
 	oldBaseDeployment(self)
 	self.Board = Board
 
@@ -294,4 +296,10 @@ function Mission_Test:MissionEnd()
 	for i, hook in ipairs(modApi.testMechExitedHooks) do
 		hook(self)
 	end
+	
+	modApi.current_mission = nil
 end
+
+sdlext.addGameExitedHook(function()
+	modApi.current_mission = nil
+end)

--- a/scripts/mod_loader/modapi/global.lua
+++ b/scripts/mod_loader/modapi/global.lua
@@ -44,17 +44,11 @@ end
 	Returns the table instance of the current mission. Returns nil when not in a mission.
 --]]
 function GetCurrentMission()
-	local region = GetCurrentRegion()
-
-	if region then
-		return GAME:GetMission(region.mission)
-	end
-
 	if IsTestMechScenario() then
 		return Mission_Test
 	end
 
-	return nil
+	return modApi.current_mission
 end
 
 function list_indexof(list, value)

--- a/scripts/mod_loader/modapi/savedata.lua
+++ b/scripts/mod_loader/modapi/savedata.lua
@@ -38,6 +38,10 @@ end
 	is currently in. Returns nil when not in a mission.
 --]]
 local function getCurrentRegion(sourceTable)
+	if not Game then
+		return
+	end
+	
     if not sourceTable then
         sourceTable = RegionData
     end


### PR DESCRIPTION
A modification for GetCurrentMission to return the correct mission after starting a new mission sooner than the current function.
Also changed GetCurrentRegion to not return anything after exiting to the main menu.