### PR TITLE
Added Board.IsTipImage and fixed Board.IsMissionBoard

### DIFF
--- a/scripts/mod_loader/altered/missions.lua
+++ b/scripts/mod_loader/altered/missions.lua
@@ -56,6 +56,7 @@ end
 
 local oldBaseUpdate = Mission.BaseUpdate
 function Mission:BaseUpdate()
+	Board.isMission = true
 	modApi.current_mission = self
 	modApi:processRunLaterQueue(self)
 
@@ -196,6 +197,7 @@ function Mission:BaseStart(suppressHooks)
 		end
 	end
 
+	Board.isMission = true
 	self.Board = Board
 	self.QueuedSpawns = {}
 
@@ -280,6 +282,7 @@ end
 -- ////////////////////////////////////////////////////////////////////
 
 function Mission_Test:BaseStart()
+	Board.isMission = true
 	Mission.BaseStart(self, true)
 
 	for i, hook in ipairs(modApi.testMechEnteredHooks) do

--- a/scripts/mod_loader/modapi/board.lua
+++ b/scripts/mod_loader/modapi/board.lua
@@ -51,14 +51,15 @@ BoardClass.GetLuaString = function(self)
 	return string.format("Board [width = %s, height = %s]", size.x, size.y)
 end
 BoardClass.GetString = BoardClass.GetLuaString
-	
-BoardClass.IsMissionBoard = function(self, mission)
+
+BoardClass.IsMissionBoard = function(self)
 	Tests.AssertEquals("userdata", type(self), "Argument #0")
+	
+	return self.isMission == true
+end
 
-	mission = mission or GetCurrentMission()
-	if not mission then
-		return false
-	end
-
-	return mission.Board == self
+BoardClass.IsTipImage = function(self)
+	Tests.AssertEquals("userdata", type(self), "Argument #0")
+	
+	return self.isMission == nil
 end


### PR DESCRIPTION
Board is unavailable in Mission.Initialize.
The soonest we see the Board is in Mission.BaseStart.

isMission must be set in BaseUpdate because it gets reset each time we look at a tipimage, and probably other times as well.

If Board was made 'sticky' somehow, we could get away with setting isMission in BaseStart and GetEnvironment instead. The latter is called before BaseUpdate after loading a game, and Board is available.