### PR TITLE
Changed when modApi.current_mission gets updated.

### DIFF
--- a/scripts/mod_loader/altered/missions.lua
+++ b/scripts/mod_loader/altered/missions.lua
@@ -56,7 +56,6 @@ end
 
 local oldBaseUpdate = Mission.BaseUpdate
 function Mission:BaseUpdate()
-	modApi.current_mission = self
 	modApi:processRunLaterQueue(self)
 
 	oldBaseUpdate(self)
@@ -179,6 +178,7 @@ function Mission:MissionEnd()
 
 	Board:AddEffect(fx)
 	self.Board = nil
+	modApi.current_mission = nil
 end
 
 function Mission:SetupDifficulty()
@@ -296,8 +296,6 @@ function Mission_Test:MissionEnd()
 	for i, hook in ipairs(modApi.testMechExitedHooks) do
 		hook(self)
 	end
-	
-	modApi.current_mission = nil
 end
 
 sdlext.addGameExitedHook(function()


### PR DESCRIPTION
modApi.current_mission is set only in two instances; when a mission starts and when a mission is loaded.
Mission.BaseDeployment.
LoadGame -> updateCurrentMission.

It is unset at two instances; when a mission ends, or when exiting to the main menu.
Mission.MissionEnd
gameExitedHook

This should be sufficient to keep current_mission up to date without having to constantly update it every game update.