### PR TITLE
Generalized method of adding hooks

### DIFF
--- a/scripts/mod_loader/altered/misc.lua
+++ b/scripts/mod_loader/altered/misc.lua
@@ -39,15 +39,11 @@ end
 
 local oldCreateIncidents = createIncidents
 function createIncidents(corporation, island)
-	for i, hook in ipairs(modApi.preIslandSelectionHooks) do
-		hook(corporation, island)
-	end
+	modApi:firePreIslandSelectionHooks(corporation, island)
 
 	oldCreateIncidents(corporation, island)
 
-	for i, hook in ipairs(modApi.postIslandSelectionHooks) do
-		hook(corporation, island)
-	end
+	modApi:firePostIslandSelectionHooks(corporation, island)
 end
 
 -- ///////////////////////////////////////////////////////////////////
@@ -71,9 +67,7 @@ local function overrideNextPhase()
 			local nextMission = _G[nxtId]
 			nextMission.ID = nxtId
 
-			for i, hook in ipairs(modApi.missionNextPhaseCreatedHooks) do
-				hook(prevMission, nextMission)
-			end
+			modApi:fireMissionNextPhaseCreatedHooks(prevMission, nextMission)
 		end
 	end
 end
@@ -97,9 +91,7 @@ function startNewGame()
 	local modOptions = mod_loader:getCurrentModContent()
 	local savedOrder = mod_loader:getCurrentModOrder()
 
-	for i, hook in ipairs(modApi.preStartGameHooks) do
-		hook()
-	end
+	modApi:firePreStartGameHooks()
 
 	oldStartNewGame()
 
@@ -124,9 +116,7 @@ function startNewGame()
 		RestoreGameVariables(Settings)
 		-- Execute hook in the deferred callback, since we want
 		-- postStartGameHook to have access to the savegame data
-		for i, hook in ipairs(modApi.postStartGameHooks) do
-			hook()
-		end
+		modApi:firePostStartGameHooks()
 	end)
 end
 
@@ -145,9 +135,7 @@ function LoadGame()
 		end
 	end
 
-	for i, hook in ipairs(modApi.preLoadGameHooks) do
-		hook()
-	end
+	modApi:firePreLoadGameHooks()
 
 	GAME.CreateNextPhase = nil
 
@@ -161,9 +149,7 @@ function LoadGame()
 		SetDifficulty(GAME.CustomDifficulty)
 	end
 
-	for i, hook in ipairs(modApi.postLoadGameHooks) do
-		hook()
-	end
+	modApi:firePostLoadGameHooks()
 	
 	modApi:runLater(function(mission)
 		mission.Board = Board
@@ -172,9 +158,7 @@ end
 
 local oldSaveGame = SaveGame
 function SaveGame()
-	for i, hook in ipairs(modApi.saveGameHooks) do
-		hook()
-	end
+	modApi:fireSaveGameHooks()
 
 	if Game and GameData then
 		-- Reload the save, since sometimes the savefile

--- a/scripts/mod_loader/altered/missions.lua
+++ b/scripts/mod_loader/altered/missions.lua
@@ -30,9 +30,7 @@ function Mission:UpdateQueuedSpawns()
 	for i = #removed, 1, -1 do
 		local spawn = removed[i]
 
-		for _, hook in ipairs(modApi.vekSpawnRemovedHooks) do
-			hook(self, spawn)
-		end
+		modApi:fireVekSpawnRemovedHooks(self, spawn)
 	end
 end
 
@@ -49,9 +47,7 @@ function Mission:BaseNextTurn()
 		end
 	end
 
-	for i, hook in ipairs(modApi.nextTurnHooks) do
-		hook(self)
-	end
+	modApi:fireNextTurnHooks(self)
 end
 
 local oldBaseUpdate = Mission.BaseUpdate
@@ -66,9 +62,7 @@ function Mission:BaseUpdate()
 		self:UpdateQueuedSpawns()
 	end
 
-	for i, hook in ipairs(modApi.missionUpdateHooks) do
-		hook(self)
-	end
+	modApi:fireMissionUpdateHooks(self)
 end
 
 local oldBaseDeployment = Mission.BaseDeployment
@@ -77,9 +71,7 @@ function Mission:BaseDeployment()
 	oldBaseDeployment(self)
 	self.Board = Board
 
-	for i, hook in ipairs(modApi.missionStartHooks) do
-		hook(self)
-	end	
+	modApi:fireMissionStartHooks(self)
 end
 
 local function overrideMissionEnd(self)
@@ -137,9 +129,7 @@ function Mission:MissionEndImpl()
 	effect.bEvacuate = true
 	effect.fDelay = 0.5
 
-	for i, hook in ipairs(modApi.preprocessVekRetreatHooks) do
-		hook(self, ret)
-	end
+	modApi:firePreprocessVekRetreatHooks(self, ret)
 	
 	local retreated = 0
 	local board_size = Board:GetSize()
@@ -147,9 +137,7 @@ function Mission:MissionEndImpl()
 		for y = 0, board_size.y - 1  do
 			local p = Point(x, y)
 			if Board:IsPawnTeam(p,TEAM_ENEMY) then
-				for i, hook in ipairs(modApi.processVekRetreatHooks) do
-					hook(self, ret, Board:GetPawn(p))
-				end
+				modApi:fireProcessVekRetreatHooks(self, ret, Board:GetPawn(p))
 
 				effect.loc = p
 				ret:AddDamage(effect)
@@ -158,9 +146,7 @@ function Mission:MissionEndImpl()
 		end
 	end
 
-	for i, hook in ipairs(modApi.postprocessVekRetreatHooks) do
-		hook(self, ret)
-	end
+	modApi:firePostprocessVekRetreatHooks(self, ret)
 	
 	ret:AddDelay(math.max(0,4 - retreated * 0.5))
 		
@@ -172,9 +158,7 @@ function Mission:MissionEnd()
 
 	self:MissionEndImpl()
 
-	for i, hook in ipairs(modApi.missionEndHooks) do
-		hook(self, fx)
-	end
+	modApi:fireMissionEndHooks(self, fx)
 	modApi.runLaterQueue = {}
 
 	Board:AddEffect(fx)
@@ -191,9 +175,7 @@ function Mission:BaseStart(suppressHooks)
 	suppressHooks = suppressHooks or false
 
 	if not suppressHooks then
-		for i, hook in ipairs(modApi.preMissionAvailableHooks) do
-			hook(self)
-		end
+		modApi:firePreMissionAvailableHooks(self)
 	end
 
 	self.Board = Board
@@ -224,9 +206,7 @@ function Mission:BaseStart(suppressHooks)
 	self.QueuedSpawns = {}
 
 	if not suppressHooks then
-		for i, hook in ipairs(modApi.postMissionAvailableHooks) do
-			hook(self)
-		end
+		modApi:firePostMissionAvailableHooks(self)
 	end
 
 	self.Initialized = true
@@ -236,9 +216,7 @@ local modLoaderHooksFired = false
 local oldApplyEnvironmentEffect = Mission.ApplyEnvironmentEffect
 function Mission:ApplyEnvironmentEffect()
 	if not modLoaderHooksFired then
-		for _, hook in ipairs(modApi.preEnvironmentHooks) do
-			hook(self)
-		end
+		modApi:firePreEnvironmentHooks(self)
 	end
 	
 	-- ApplyEnvironmentEffect() is supposed to return true once
@@ -261,9 +239,7 @@ function Mission:ApplyEnvironmentEffect()
 					return
 				end
 				
-				for _, hook in ipairs(modApi.postEnvironmentHooks) do
-					hook(self)
-				end
+				modApi:firePostEnvironmentHooks(self)
 			end
 		)
 		
@@ -282,9 +258,7 @@ end
 function Mission_Test:BaseStart()
 	Mission.BaseStart(self, true)
 
-	for i, hook in ipairs(modApi.testMechEnteredHooks) do
-		hook(self)
-	end
+	modApi:fireTestMechEnteredHooks(self)
 end
 
 -- MissionEnd is not actually called when exiting test mech scenario;
@@ -293,9 +267,7 @@ function Mission_Test:MissionEnd()
 	-- DON'T call the default MissionEnd
 	-- Mission.MissionEnd(self)
 
-	for i, hook in ipairs(modApi.testMechExitedHooks) do
-		hook(self)
-	end
+	modApi:fireTestMechExitedHooks(self)
 	
 	modApi.current_mission = nil
 end

--- a/scripts/mod_loader/altered/spawn_point.lua
+++ b/scripts/mod_loader/altered/spawn_point.lua
@@ -63,9 +63,7 @@ local function addSpawnData(self, location, type, id, age)
 
 	if self.Initialized then
 		-- Don't trigger the hooks when missions become available
-		for i, hook in ipairs(modApi.vekSpawnAddedHooks) do
-			hook(self, el)
-		end
+		modApi:fireVekSpawnAddedHooks(self, el)
 	end
 end
 

--- a/scripts/mod_loader/modapi/hooks.lua
+++ b/scripts/mod_loader/modapi/hooks.lua
@@ -2,143 +2,74 @@
 -- //////////////////////////////////////////////////////////////////////////////
 -- Simple hooks
 
-function modApi:addPreMissionAvailableHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.preMissionAvailableHooks,fn)
+modApi.hooks = {}
+
+function modApi:AddHook(name)
+	local Name = name:gsub("^.", string.upper) -- capitalize first letter
+	local name = name:gsub("^.", string.lower) -- lower case first letter
+
+	table.insert(self.hooks, name)
+	self[name .."Hooks"] = {}
+
+	self["add".. Name .."Hook"] = function(self, fn)
+		assert(type(fn) == "function")
+		table.insert(self[name .."Hooks"], fn)
+	end
+
+	self["rem".. Name .."Hook"] = function(self, fn)
+		remove_element(fn, self[name .."Hooks"])
+	end
+
+	self["fire".. Name .."Hooks"] = function(self, ...)
+		for _, fn in ipairs(self[name .."Hooks"]) do
+			fn(...)
+		end
+	end
 end
 
-function modApi:addPostMissionAvailableHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.postMissionAvailableHooks,fn)
+function modApi:ResetHooks()
+	for _, name in ipairs(self.hooks) do
+		self[name .."Hooks"] = {}
+	end
 end
 
+local hooks = {
+	"PreMissionAvailable",
+	"PostMissionAvailable",
+	"PreEnvironment",
+	"PostEnvironment",
+	"NextTurn",
+	"VoiceEvent",
+	"PreIslandSelection",
+	"PostIslandSelection",
+	"MissionUpdate",
+	"MissionStart",
+	"MissionEnd",
+	"MissionNextPhaseCreated",
+	"PreStartGame",
+	"PostStartGame",
+	"PreLoadGame",
+	"PostLoadGame",
+	"SaveGame",
+	"VekSpawnAdded",
+	"VekSpawnRemoved",
+	"PreprocessVekRetreat",
+	"ProcessVekRetreat",
+	"PostprocessVekRetreat",
+	"ModsLoaded",
+	"ModsInitialized",
+	"TestMechEntered",
+	"TestMechExited",
+	"SaveDataUpdated",
+}
+
+for _, name in ipairs(hooks) do
+	modApi:AddHook(name)
+end
+
+-- backwards compatibility.
 function modApi:addMissionAvailableHook(fn)
 	self:addPostMissionAvailableHook(fn)
-end
-
-function modApi:addPreEnvironmentHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.preEnvironmentHooks,fn)
-end
-
-function modApi:addPostEnvironmentHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.postEnvironmentHooks,fn)
-end
-
-function modApi:addNextTurnHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.nextTurnHooks,fn)
-end
-
-function modApi:addVoiceEventHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.voiceEventHooks,fn)
-end
-
-function modApi:addPreIslandSelectionHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.preIslandSelectionHooks,fn)
-end
-
-function modApi:addPostIslandSelectionHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.postIslandSelectionHooks,fn)
-end
-
-function modApi:addMissionUpdateHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.missionUpdateHooks,fn)
-end
-
-function modApi:addMissionStartHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.missionStartHooks,fn)
-end
-
-function modApi:addMissionEndHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.missionEndHooks,fn)
-end
-
-function modApi:addMissionNextPhaseCreatedHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.missionNextPhaseCreatedHooks,fn)
-end
-
-function modApi:addPreStartGameHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.preStartGameHooks,fn)
-end
-
-function modApi:addPostStartGameHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.postStartGameHooks,fn)
-end
-
-function modApi:addPreLoadGameHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.preLoadGameHooks,fn)
-end
-
-function modApi:addPostLoadGameHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.postLoadGameHooks,fn)
-end
-
-function modApi:addSaveGameHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.saveGameHooks,fn)
-end
-
-function modApi:addVekSpawnAddedHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.vekSpawnAddedHooks,fn)
-end
-
-function modApi:addVekSpawnRemovedHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.vekSpawnRemovedHooks,fn)
-end
-
-function modApi:addPreprocessVekRetreatHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.preprocessVekRetreatHooks,fn)
-end
-
-function modApi:addProcessVekRetreatHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.processVekRetreatHooks,fn)
-end
-
-function modApi:addPostprocessVekRetreatHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.postprocessVekRetreatHooks,fn)
-end
-
-function modApi:addModsLoadedHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.modsLoadedHooks,fn)
-end
-
-function modApi:addModsInitializedHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.modsInitializedHooks,fn)
-end
-
-function modApi:addTestMechEnteredHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.testMechEnteredHooks,fn)
-end
-
-function modApi:addTestMechExitedHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.testMechExitedHooks,fn)
-end
-
-function modApi:addSaveDataUpdatedHook(fn)
-	assert(type(fn) == "function")
-	table.insert(self.saveDataUpdatedHooks,fn)
 end
 
 -- //////////////////////////////////////////////////////////////////////////////

--- a/scripts/mod_loader/modapi/init.lua
+++ b/scripts/mod_loader/modapi/init.lua
@@ -287,32 +287,7 @@ function modApi:resetModContent()
 
 	self.conditionalHooks = {}
 	self.scheduledHooks = {}
-	self.nextTurnHooks = {}
-	self.missionUpdateHooks = {}
-	self.missionStartHooks = {}
-	self.missionNextPhaseCreatedHooks = {}
-	self.preMissionAvailableHooks = {}
-	self.postMissionAvailableHooks = {}
-	self.preEnvironmentHooks = {}
-	self.postEnvironmentHooks = {}
-	self.preStartGameHooks = {}
-	self.postStartGameHooks = {}
-	self.preLoadGameHooks = {}
-	self.postLoadGameHooks = {}
-	self.saveGameHooks = {}
-	self.voiceEventHooks = {}
-	self.preIslandSelectionHooks = {}
-	self.postIslandSelectionHooks = {}
-	self.missionEndHooks = {}
-	self.vekSpawnAddedHooks = {}
-	self.vekSpawnRemovedHooks = {}
-	self.preprocessVekRetreatHooks = {}
-	self.processVekRetreatHooks = {}
-	self.postprocessVekRetreatHooks = {}
-	self.modsLoadedHooks = {}
-	self.testMechEnteredHooks = {}
-	self.testMechExitedHooks = {}
-	self.saveDataUpdatedHooks = {}
+	self:ResetHooks()
 
 	local name, tbl = debug.getupvalue(oldGetPopulationTexts,1)
 	self.PopEvents = copy_table(tbl)

--- a/scripts/mod_loader/modapi/savedata.lua
+++ b/scripts/mod_loader/modapi/savedata.lua
@@ -153,9 +153,7 @@ local function restoreGameVariables(settings)
 		RegionData = env.RegionData
 		SquadData = env.SquadData
 		
-		for _, hook in ipairs(modApi.saveDataUpdatedHooks) do
-			hook()
-		end
+		modApi:fireSaveDataUpdatedHooks()
 	end
 end
 


### PR DESCRIPTION
New functions:
1. modApi.AddHook - creating add-, rem- and fire- functions for an event.

Example:
modApi:AddHook("MissionStart")

creates the following three functions to be used by modders:
modApi:addMissionStartHook(function)
modApi:remMissionStartHook(function)
modApi:fireMissionStartHook(param1, param2, ...)


2. modApi:ResetHooks() - clears every hooks. Intended to be used in modApi.resetModContent