### PR TITLE
Fixed HangarGetSelectedMechs

### DIFF
--- a/scripts/mod_loader/modui/hangar.lua
+++ b/scripts/mod_loader/modui/hangar.lua
@@ -130,9 +130,10 @@ end
 
 local function overrideGetImages()
 	pawns = {}
-
+	local wasPrimaryCallExecuted = false
+	
 	for k, v in pairs(_G) do
-		if type(v) == "table" and v.Health and v.Image then
+		if type(v) == "table" and v ~= PawnTable and v.Health and v.Image then
 			table.insert(pawns, k)
 
 			if v.GetImage then
@@ -141,16 +142,26 @@ local function overrideGetImages()
 				oldGetImages[k] = defaultGetImage
 			end
 
-			v.GetImage = function(self, parent)
+			v.GetImage = function(self)
+				local isPrimaryCall = not wasPrimaryCallExecuted
+
 				if
-					not parent                and
+					isPrimaryCall             and
 					IsHangarWindowlessState() and
 					#fetchedMechs < 3
 				then
 					table.insert(fetchedMechs, k)
 				end
 
-				return oldGetImages[k](self, true)
+				if isPrimaryCall then
+					wasPrimaryCallExecuted = true
+				end
+				local result = oldGetImages[k](self)
+				if isPrimaryCall then
+					wasPrimaryCallExecuted = false
+				end
+
+				return result
 			end
 		end
 	end

--- a/scripts/mod_loader/modui/hangar.lua
+++ b/scripts/mod_loader/modui/hangar.lua
@@ -141,15 +141,16 @@ local function overrideGetImages()
 				oldGetImages[k] = defaultGetImage
 			end
 
-			v.GetImage = function(self)
+			v.GetImage = function(self, parent)
 				if
+					not parent                and
 					IsHangarWindowlessState() and
 					#fetchedMechs < 3
 				then
 					table.insert(fetchedMechs, k)
 				end
 
-				return oldGetImages[k](self)
+				return oldGetImages[k](self, true)
 			end
 		end
 	end


### PR DESCRIPTION
With the addition of PawnTable in modapi/pawn.lua; every table deriving from it will have several GetImage overrides.
This change ensures only one call is made to table.insert(fetchedMechs... for each mech. (in modui/hangar.lua)