### PR TITLE
Truncated PilotList in hangar

### DIFF
--- a/scripts/mod_loader/altered/misc.lua
+++ b/scripts/mod_loader/altered/misc.lua
@@ -185,6 +185,28 @@ function CreateEffect(data)
 	return effect
 end
 
+local oldGetPilotDrop = getPilotDrop
+function getPilotDrop()
+	local oldPilotList = PilotList
+	PilotList = PilotListExtended
+	
+	local result = oldGetPilotDrop()
+	
+	PilotList = oldPilotList
+	
+	return result
+end
+
+local oldInitializeDecks = initializeDecks
+function initializeDecks()
+	local oldPilotList = PilotList
+	PilotList = PilotListExtended
+	
+	oldInitializeDecks()
+	
+	PilotList = oldPilotList
+end
+
 Effect.GetLuaString = function(self)
 	return string.format("CreateEffect(%s)", save_table(self.data))
 end

--- a/scripts/mod_loader/mod_loader.lua
+++ b/scripts/mod_loader/mod_loader.lua
@@ -71,6 +71,7 @@ function mod_loader:init()
 	modApi:finalize()
 	
 	self:loadModContent(self:getModConfig(), self:getSavedModOrder())
+	self:loadPilotList()
 end
 
 function mod_loader:enumerateMods()
@@ -440,6 +441,16 @@ function mod_loader:loadModContent(mod_options,savedOrder)
 		if not ok then
 			LOG("A modsLoadedHook failed: ", err)
 		end
+	end
+end
+
+function mod_loader:loadPilotList()
+	loadPilotsOrder()
+	PilotList = {}
+	
+	local max_pilots = 13
+	for i = 1, max_pilots do
+		PilotList[i] = PilotListExtended[i]
 	end
 end
 

--- a/scripts/mod_loader/modapi/global.lua
+++ b/scripts/mod_loader/modapi/global.lua
@@ -16,13 +16,18 @@ function CreatePilotPersonality(label, name)
 	return t
 end
 
+PilotListExtended = shallow_copy(PilotList)
+
 function CreatePilot(data)
 	_G[data.Id] = Pilot:new(data)
 
 	-- Make sure we don't create duplicates if the PilotList
 	-- already contains entry for this pilot
 	if data.Rarity ~= 0 and not list_contains(PilotList, data.Id) then
-		PilotList[#PilotList + 1] = data.Id
+		if #PilotList < 13 then
+			PilotList[#PilotList + 1] = data.Id
+		end
+		PilotListExtended[#PilotListExtended + 1] = data.Id
 	end
 end
 

--- a/scripts/mod_loader/modui/pilot_arrange.lua
+++ b/scripts/mod_loader/modui/pilot_arrange.lua
@@ -4,6 +4,8 @@
 	for selection in the hangar.
 --]]
 
+local MAX_PILOTS = 13
+
 function loadPilotsOrder()
 	local order = {}
 
@@ -14,12 +16,12 @@ function loadPilotsOrder()
 			order[v] = k
 		end
 	end)
-	for k, v in ipairs(PilotList) do
+	for k, v in ipairs(PilotListExtended) do
 		if order[v] == nil then
 			order[v] = 10000 + k
 		end
 	end
-	table.sort(PilotList,function(a,b)
+	table.sort(PilotListExtended,function(a,b)
 		return order[a] < order[b]
 	end)
 end
@@ -38,7 +40,7 @@ local function createUi()
 	local onExit = function(self)
 		PilotList = {}
 
-		for i = 1, #pilotButtons do
+		for i = 1, MAX_PILOTS do
 			PilotList[i] = pilotButtons[i].pilotId
 		end
 		
@@ -170,8 +172,8 @@ local function createUi()
 		end
 		
 		local dupes = {}
-		for i = 1, #PilotList do
-			local pilotId = PilotList[i]
+		for i = 1, #PilotListExtended do
+			local pilotId = PilotListExtended[i]
 			if not dupes[pilotId] then 
 				dupes[pilotId] = 1
 				addPilotButton(#pilotButtons + 1, pilotId)


### PR DESCRIPTION
Truncates pilot list while in the hangar to the 13 first selected, while still allowing all pilots to be found from pods and perfect island rewards.