### PR TITLE
Events

### DIFF
--- a/scripts/mod_loader/altered/__scripts.lua
+++ b/scripts/mod_loader/altered/__scripts.lua
@@ -2,6 +2,7 @@ local scripts = {
 	"difficulty",
 	"misc",
 	"missions",
+	"missions_additional",
 	"skills",
 	"spawn_point",
 	"squad",

--- a/scripts/mod_loader/altered/missions_additional.lua
+++ b/scripts/mod_loader/altered/missions_additional.lua
@@ -1,0 +1,128 @@
+
+-- All of this code is extracted from altered/missions.lua
+-- With an events based system different parts could be moved around
+-- to where their respective subject matter is coded.
+
+--[[
+	pros:
+		A specific subject matter can have all of
+		it's logic grouped together in the same file.
+		
+	cons:
+		You cannot look at any given function and know which
+		function are being called and which variables are being set.
+]]
+
+modApi:addMissionCreatedEvent(function(self)
+	self.Initialized = false
+end)
+
+modApi:addMissionBaseNextTurnEvent(function(self)
+	self.Board = Board
+
+	if Game:GetTeamTurn() == TEAM_PLAYER then
+		self:UpdateQueuedSpawns()
+
+		for i, el in ipairs(self.QueuedSpawns) do
+			el.turns = el.turns + 1
+		end
+	end
+
+	modApi:fireNextTurnHooks(self)
+end)
+
+modApi:addPreMissionBaseUpdateEvent(function(self)
+	modApi.current_mission = self
+	modApi:processRunLaterQueue(self)
+end)
+
+modApi:addPostMissionBaseUpdateEvent(function(self)
+	if Board:GetBusyState() == 6 then
+		-- BusyState 6 happens when Vek are burrowing out of the ground
+		self:UpdateQueuedSpawns()
+	end
+
+	modApi:fireMissionUpdateHooks(self)
+end)
+
+modApi:addPreMissionBaseDeploymentEvent(function(self)
+	modApi.current_mission = self
+end)
+
+modApi:addPostMissionBaseDeploymentEvent(function(self)
+	self.Board = Board
+
+	modApi:fireMissionStartHooks(self)
+end)
+
+modApi:addMissionMissionEndEvent(function(self)
+	local fx = SkillEffect()
+
+	modApi:fireMissionEndHooks(self, fx)
+	fx:AddScript([[
+		modApi.runLaterQueue = {}
+		
+		modApi:conditionalHook(
+			BuildIsBoardBusyPredicate(modApi.current_mission.Board),
+			function()
+				-- BoardBusyPredicate defined above will yield true once we exit to main menu,
+				-- but when that happens, current_mission is reset to nil.
+				if modApi.current_mission then
+					modApi.current_mission.Board = nil
+					modApi.current_mission = nil
+				end
+			end
+		)
+	]])
+	Board:AddEffect(fx)
+end)
+
+modApi:addPreMissionBaseStartEvent(function(self)
+	if self ~= Mission_Test then
+		modApi:firePreMissionAvailableHooks(self)
+	end
+
+	self.Board = Board
+	self.QueuedSpawns = {}
+end)
+
+modApi:addPostMissionBaseStartEvent(function(self)
+	-- Clear QueuedSpawns, since the Vek burrow out immediately when entering the mission
+	self.QueuedSpawns = {}
+
+	if self ~= Mission_Test then
+		modApi:firePostMissionAvailableHooks(self)
+	else
+		modApi:fireTestMechEnteredHooks(self)
+	end
+
+	self.Initialized = true
+end)
+
+local modLoaderHooksFired = false
+modApi:addPreMissionApplyEnvironmentEffectEvent(function(self)
+	if not modLoaderHooksFired then
+		modApi:firePreEnvironmentHooks(self)
+	end
+end)
+
+modApi:addPostMissionApplyEnvironmentEffectEvent(function(self)
+	if not modLoaderHooksFired then
+		-- Schedule the post hooks to fire once the board is no longer busy
+		modApi:conditionalHook(
+			function()
+				return not Game or not GAME or (Board and not Board:IsBusy())
+			end,
+			function()
+				modLoaderHooksFired = false
+				if not Game or not GAME or not Board then
+					return
+				end
+				
+				modApi:firePostEnvironmentHooks(self)
+			end
+		)
+		
+		modLoaderHooksFired = true
+	end
+end)

--- a/scripts/mod_loader/modapi/__scripts.lua
+++ b/scripts/mod_loader/modapi/__scripts.lua
@@ -1,5 +1,6 @@
 local scripts = {
 	"init",
+	"events/__scripts",
 	"global",
 	"ftldat",
 	"misc",

--- a/scripts/mod_loader/modapi/events/__scripts.lua
+++ b/scripts/mod_loader/modapi/events/__scripts.lua
@@ -1,0 +1,10 @@
+local scripts = {
+	"events",
+	"global",
+	"missions",
+}
+
+local rootpath = GetParentPath(...)
+for i, filepath in ipairs(scripts) do
+	require(rootpath..filepath)
+end

--- a/scripts/mod_loader/modapi/events/events.lua
+++ b/scripts/mod_loader/modapi/events/events.lua
@@ -1,0 +1,59 @@
+
+-- Basically the same as hooks, with the exception that they are not reset after loading.
+-- Intended for streamlining the modApi's inner workings,
+-- so different parts can be grouped in a more meaningful way.
+modApi.events = {}
+
+function modApi:newEvent(name)
+	local Event = name:gsub("^.", string.upper) .."Event" -- capitalize first char
+	local name = name:gsub("^.", string.lower) -- lower case first char
+	
+	table.insert(self.events, name)
+	local events = {}
+	self[name .."Events"] = events
+
+	self["add".. Event] = function(self, fn)
+		assert(type(fn) == "function")
+		table.insert(events, fn)
+	end
+
+	self["rem".. Event] = function(self, fn)
+		remove_element(fn, events)
+	end
+
+	self["trigger".. Event] = function(self, ...)
+		for _, fn in ipairs(events) do
+			fn(...)
+		end
+	end
+end
+
+function modApi:triggerEvent(name, ...)
+	local name = name:gsub("^.", string.upper) -- capitalize first char
+	
+	self["trigger".. name .."Event"](self, ...)
+end
+
+-- Creates pre-, post- and - event triggers for a table function.
+-- This pattern is not always applicable, and triggers can be created manually instead.
+function modApi:addEventTriggers(parentTable, key, event)
+
+	event = event:gsub("^.", string.upper) -- capitalize first char
+	local event_pre = "Pre".. event
+	local event_post = "Post".. event
+	
+	local oldFn = parentTable[key]
+	
+	assert(type(oldFn) == 'function')
+	
+	parentTable[key] = function(...)
+		self:triggerEvent(event_pre, ...)
+		
+		local result = oldFn(...)
+		
+		self:triggerEvent(event, ...) -- if pre/post is not specified, post makes most sense.
+		self:triggerEvent(event_post, ...)
+		
+		return result
+	end
+end

--- a/scripts/mod_loader/modapi/events/global.lua
+++ b/scripts/mod_loader/modapi/events/global.lua
@@ -1,0 +1,10 @@
+
+modApi:newEvent("GameLoaded")
+modApi:newEvent("preGameLoaded")
+modApi:newEvent("postGameLoaded")
+modApi:newEvent("GameSaved")
+modApi:newEvent("preGameSaved")
+modApi:newEvent("postGameSaved")
+
+modApi:addEventTriggers(_G, 'LoadGame', "GameLoaded")
+modApi:addEventTriggers(_G, 'SaveGame', "GameSaved")

--- a/scripts/mod_loader/modapi/events/missions.lua
+++ b/scripts/mod_loader/modapi/events/missions.lua
@@ -1,0 +1,78 @@
+
+modApi:newEvent("MissionReloaded")
+modApi:newEvent("PreMissionReloaded")
+modApi:newEvent("PostMissionReloaded")
+modApi:newEvent("MissionCreated")
+modApi:newEvent("PreMissionCreated")
+modApi:newEvent("PostMissionCreated")
+
+local exclusions = {
+	"Initialize"
+}
+
+-- Create event listeners for every function in Mission class
+local missionKeys = {}
+for key, fn in pairs(Mission) do
+	
+	if type(fn) == 'function' then
+		
+		if not list_contains(exclusions, key) then
+			
+			local event = "Mission".. key:gsub("^.", string.upper) -- capitalize first letter
+			local event_pre = "Pre".. event
+			local event_post = "Post".. event
+			
+			modApi:newEvent(event)
+			modApi:newEvent(event_pre)
+			modApi:newEvent(event_post)
+			
+			missionKeys[#missionKeys + 1] = key
+		end
+	end
+end
+
+-- We keep all functions in Mission intact,
+-- and add event triggers to mission instances as they are created.
+-- This way, events will only trigger once,
+-- even if an overriding function calls back it's overridden base function.
+modApi:addMissionCreatedEvent(function(mission)
+	for _, key in ipairs(missionKeys) do
+		modApi:addEventTriggers(mission, key, "Mission".. key)
+	end
+end)
+
+local oldCreateMission = CreateMission
+function CreateMission(mission_base)
+	modApi:triggerEvent("PreMissionCreated", mission_base)
+	
+	local mission = oldCreateMission(mission_base)
+	
+	modApi:triggerEvent("MissionCreated", mission)
+	modApi:triggerEvent("PostMissionCreated", mission)
+	
+	return mission
+end
+
+-- full override so we can add triggers to CreateSpawner before calling it.
+function ReloadMissions(missions)
+    if missions == nil then
+        return
+    end
+	
+	for _, mission in pairs(missions) do
+		local baseMission = mission.ID
+		modApi:triggerEvent("PreMissionReloaded", baseMission)
+		
+		mission = _G[baseMission]:new(mission)
+		
+		for _, key in ipairs(missionKeys) do
+			modApi:addEventTriggers(mission, key, "Mission".. key)
+		end
+		
+		mission:CreateSpawner(mission.Spawner)
+		mission.LiveEnvironment = _G[mission.Environment]:new(mission.LiveEnvironment)
+		
+		modApi:triggerEvent("MissionReloaded", mission)
+		modApi:triggerEvent("PostMissionReloaded", mission)
+	end
+end


### PR DESCRIPTION
The first step in making the mod loader events driven.

Code from `altered/mission` has been moved to `altered/mission_additional` where it is run via events instead of inserted directly into the functions where the code needed to be executed. It should be functionally the same as the old code.

A next step could be to move code out of `altered/mission_additional` to group everything that logiocally relates to the same features together.