### PR TITLE
Fix invalid language indexes crashing the modloader

### DIFF
--- a/scripts/mod_loader/modapi/localization.lua
+++ b/scripts/mod_loader/modapi/localization.lua
@@ -13,6 +13,10 @@ Languages = {
 	Spanish = 9,
 	Japanese = 10
 }
+local languageNames = {}
+for name, index in pairs(Languages) do
+	languageNames[index] = name
+end
 
 local languageDisplayNames = {}
 languageDisplayNames[Languages.English] = Global_Texts.Language_English
@@ -30,7 +34,11 @@ languageDisplayNames[Languages.Japanese] = Global_Texts.Language_Japanese
 	Returns the index representing currently selected language.
 --]]
 function modApi:getLanguageIndex()
-	return Settings.language
+	local index = Settings and Settings.language or nil
+	if index == nil or languageNames[index] == nil then
+		return Languages.English
+	end
+	return index
 end
 
 --[[
@@ -40,13 +48,7 @@ function modApi:getLanguageId(languageIndex)
 	languageIndex = languageIndex or self:getLanguageIndex()
 	assert(type(languageIndex) == "number", "Language index must be a number")
 
-	for k, v in pairs(Languages) do
-		if v == languageIndex then
-			return k
-		end
-	end
-
-	return nil
+	return languageNames[index] or "English"
 end
 
 --[[

--- a/scripts/mod_loader/modui/hangar.lua
+++ b/scripts/mod_loader/modui/hangar.lua
@@ -604,19 +604,22 @@ local function getLanguageRectsMap()
 	return languageRectsMap
 end
 
-function GetBackButtonRect(languageIndex)
+local function GetLanguageButton(name, languageIndex)
 	languageIndex = languageIndex or modApi:getLanguageIndex()
-	return getLanguageRectsMap().btnBack[languageIndex]
+	local buttons = getLanguageRectsMap()[name]
+	return buttons[languageIndex] or buttons[Languages.English]
+end
+
+function GetBackButtonRect(languageIndex)
+	return GetLanguageButton("btnBack", languageIndex)
 end
 
 function GetStartButtonRect(languageIndex)
-	languageIndex = languageIndex or modApi:getLanguageIndex()
-	return getLanguageRectsMap().btnStart[languageIndex]
+	return GetLanguageButton("btnStart", languageIndex)
 end
 
 function GetDifficultyRect(languageIndex)
-	languageIndex = languageIndex or modApi:getLanguageIndex()
-	return getLanguageRectsMap().difficulty[languageIndex]
+	return GetLanguageButton("difficulty", languageIndex)
 end
 
 local function setupButtonBack(btnBack)


### PR DESCRIPTION
If settings.lua is missing, or has no language index, the default value is 0. This is problematic, as English's language index is 1, and the mod loader expects the language index to always be valid.

This PR fixes the internal function to get the language ID so it always returns a valid language index, defaulting to English if invalid. It also makes functions that take a language index default to the English version if the index is missing.