### PR TITLE
Added backwards compatibility code to GetText for modded weapon ugprades

### DIFF
--- a/scripts/mod_loader/altered/text.lua
+++ b/scripts/mod_loader/altered/text.lua
@@ -43,3 +43,10 @@ function GetText(id, r1, r2, r3)
 		return text
 	end
 end
+
+local vanillaGetPilotDialog = GetPilotDialog
+function GetPilotDialog(personality, event)
+	local result = vanillaGetPilotDialog(personality, event)
+	
+	return GetPilotDialog_Deprecated(personality, event)
+end

--- a/scripts/mod_loader/altered/text.lua
+++ b/scripts/mod_loader/altered/text.lua
@@ -43,3 +43,14 @@ function GetText(id, r1, r2, r3)
 		return text
 	end
 end
+
+local vanillaGetPilotDialog = GetPilotDialog
+function GetPilotDialog(...)
+    local result = vanillaGetPilotDialog(...)
+    
+    if result == "" then
+        result = GetPilotDialog_Deprecated(...)
+    end
+    
+    return result
+end

--- a/scripts/mod_loader/altered/text.lua
+++ b/scripts/mod_loader/altered/text.lua
@@ -43,10 +43,3 @@ function GetText(id, r1, r2, r3)
 		return text
 	end
 end
-
-local vanillaGetPilotDialog = GetPilotDialog
-function GetPilotDialog(personality, event)
-	local result = vanillaGetPilotDialog(personality, event)
-	
-	return GetPilotDialog_Deprecated(personality, event)
-end

--- a/scripts/mod_loader/altered/text.lua
+++ b/scripts/mod_loader/altered/text.lua
@@ -27,6 +27,19 @@ function GetText(id, r1, r2, r3)
 
 		return text
 	else
-		return GetVanillaText(id, r1, r2, r3)
+		text = GetVanillaText(id, r1, r2, r3)
+		
+		if text == id then
+			if id:match("Upgrade%d$") then
+				local skill = _G[id:sub(1,-10)]
+				local upgrade = tonumber(id:sub(-1,-1))
+				
+				if type(skill) == 'table' and type(skill.UpgradeList) == 'table' then
+					text = skill.UpgradeList[upgrade] or text
+				end
+			end
+		end
+		
+		return text
 	end
 end


### PR DESCRIPTION
With ITB version 1.2 - weapon upgrade names stored in `MyWeapon.UpgradeList` are ignored. This change reenables that functionality so old mods using that method don't need to be updated to work as they did before.