### PR TITLE
Allow rearranging pilots after hitting new game

### DIFF
--- a/scripts/mod_loader/localization/dictionary_English.lua
+++ b/scripts/mod_loader/localization/dictionary_English.lua
@@ -23,7 +23,7 @@ return {
 
 	["ModContent_Button_PilotArrange"] = "Arrange Pilots",
 	["ModContent_ButtonTooltip_PilotArrange"] = "Select which pilots will be available to pick.",
-	["PilotArrange_ButtonTooltip_Off"] = "Pilots can only be arranged before the New Game button is pressed.\n\nRestart the game to be able to arrange pilots.",
+	["PilotArrange_ButtonTooltip_Off"] = "New Game was pressed, so the pilots in the hangar can no longer be updated.\n\nYou must restart the game for changes to take effect.",
 	["PilotArrange_FrameTitle"] = "Arrange Pilots",
 
 	["ModContent_Button_ModLoaderConfig"] = "Configure Mod Loader",


### PR DESCRIPTION
Currently, you cannot altar pilot order after hitting new game. However, a lot of mod UIs can only be changed on restart, making pilots the inconsistent one as it is locked out by a screen after the main menu. This pull request allows you to change the list after hitting new game, but the changes after will require a restart to take effect. This also changes the tooltip of the button after you enter the hangar, to make it clear changes require a restart.

In my testing, you can still rearrange pilots before hitting new game as before. Once you hit new game, rearranging the pilots has no effect, but your order still shows in the UI and will update on game restart.