### PR TITLE
Fix wrong variable name in localization ID fetch

### DIFF
--- a/scripts/mod_loader/modapi/localization.lua
+++ b/scripts/mod_loader/modapi/localization.lua
@@ -48,7 +48,7 @@ function modApi:getLanguageId(languageIndex)
 	languageIndex = languageIndex or self:getLanguageIndex()
 	assert(type(languageIndex) == "number", "Language index must be a number")
 
-	return languageNames[index] or "English"
+	return languageNames[languageIndex] or "English"
 end
 
 --[[


### PR DESCRIPTION
Realized I had a typo in the localization default logic from #35. Causes all languages to return as English unless some mod globally sets `index`.