### PR TITLE
Fix pilots not being unlockable

### DIFF
--- a/scripts/mod_loader/altered/misc.lua
+++ b/scripts/mod_loader/altered/misc.lua
@@ -185,27 +185,32 @@ function CreateEffect(data)
 	return effect
 end
 
-local oldGetPilotDrop = getPilotDrop
-function getPilotDrop()
-	local oldPilotList = PilotList
-	PilotList = PilotListExtended
-	
-	local result = oldGetPilotDrop()
-	
-	PilotList = oldPilotList
-	
-	return result
-end
-
+-- initializeDecks is called before the game entered hook, so we still need this override
 local oldInitializeDecks = initializeDecks
 function initializeDecks()
 	local oldPilotList = PilotList
 	PilotList = PilotListExtended
-	
 	oldInitializeDecks()
-	
 	PilotList = oldPilotList
 end
+
+-- a pilot must be in PilotList to be unlocked, however we cannot have more than 13 pilots in the list for the UI
+-- fix that by using PilotListExtended in game, and the smaller pilot list in the hangar
+local hangarPilotList = nil
+sdlext.addGameEnteredHook(function()
+	-- prevent overwriting the list twice accidently
+	if hangarPilotList == nil then
+		hangarPilotList = PilotList
+		PilotList = PilotListExtended
+	end
+end)
+sdlext.addGameExitedHook(function()
+	-- only update if we have an old list
+	if hangarPilotList ~= nil then
+		PilotList = hangarPilotList
+		hangarPilotList = nil
+	end
+end)
 
 Effect.GetLuaString = function(self)
 	return string.format("CreateEffect(%s)", save_table(self.data))


### PR DESCRIPTION
A pilot must exist in PilotList in order to be unlocked, but modloader only included the first 13 pilots in that list as we can have at most 13 for the hangar. This fixes it to swap the pilot list for the full one when entering and leaving the game.

Note that this currently conflicts with #38, but since this pull request is a lot easier to review I suggest merging it first and I will update #38.