### PR TITLE
Added sorting to mod configuration

### DIFF
--- a/scripts/mod_loader/localization/dictionary_English.lua
+++ b/scripts/mod_loader/localization/dictionary_English.lua
@@ -11,6 +11,11 @@ return {
 	["ModContent_Button_ModConfig"] = "Configure Mods",
 	["ModContent_ButtonTooltip_ModConfig"] = "Turn on and off individual mods, and configure any settings they might have.",
 	["ModConfig_FrameTitle"] = "Mod Configuration",
+	["ModConfig_Button_Sort_Title"] = "Sort by:",
+	["ModConfig_Button_Sort_Tooltip"] = "Sort mods alphabetically by name, id or sort them in the order they were loaded.",
+	["ModConfig_Button_Sort_Choice_1"] = "Name",
+	["ModConfig_Button_Sort_Choice_2"] = "Id",
+	["ModConfig_Button_Sort_Choice_3"] = "Load Order",
 
 	["ModContent_Button_SquadSelect"] = "Edit Squads",
 	["ModContent_ButtonTooltip_SquadSelect"] = "Select which squads will be available to pick.",

--- a/scripts/mod_loader/localization/dictionary_English.lua
+++ b/scripts/mod_loader/localization/dictionary_English.lua
@@ -15,7 +15,11 @@ return {
 	["ModConfig_Button_Sort_Tooltip"] = "Sort mods alphabetically by name, id or sort them in the order they were loaded.",
 	["ModConfig_Button_Sort_Choice_1"] = "Name",
 	["ModConfig_Button_Sort_Choice_2"] = "Id",
-	["ModConfig_Button_Sort_Choice_3"] = "Load Order",
+	["ModConfig_Button_Sort_Enabled_Mods_Title"] = "Enabled Mods:",
+	["ModConfig_Button_Sort_Enabled_Mods_Tooltip"] = "Sort enabled mods before or after disabled mods",
+	["ModConfig_Button_Sort_Enabled_Mods_Choice_1"] = "First",
+	["ModConfig_Button_Sort_Enabled_Mods_Choice_2"] = "Last",
+	["ModConfig_Button_Sort_Enabled_Mods_Choice_3"] = "Unsorted",
 
 	["ModContent_Button_SquadSelect"] = "Edit Squads",
 	["ModContent_ButtonTooltip_SquadSelect"] = "Select which squads will be available to pick.",


### PR DESCRIPTION
Added a dropdown button to the mod configuration window, able to sort mods by name, id or load order.

Sorting by name and id will sort every mod, enabled or not, according to sorting option.
Sorting by load order will sort every already enabled mod according to the order they were sorted at current mod loader initialization, while the remaining mods are sorted by id.
Mods enabled or disabled after mod loader init will not be sorted by load order, since they have not been loaded.