### PR TITLE
Testing console improvements

### DIFF
--- a/scripts/mod_loader/modui/tests_console.lua
+++ b/scripts/mod_loader/modui/tests_console.lua
@@ -112,7 +112,7 @@ end
 
 local function buildTestsuiteUi(testsuiteEntry, isNestedTestsuite)
 	indentLevel = indentLevel or 0
-	local tests, testsuites = testsuiteEntry.suite:EnumerateTests()
+	local tests, testsuites = testsuiteEntry.suite:EnumerateTestsAndTestsuites()
 
 	local entryBoxHolder = UiBoxLayout()
 		:vgap(5)
@@ -242,9 +242,9 @@ local function buildTestsuiteUi(testsuiteEntry, isNestedTestsuite)
 		end
 	end
 
-	table.insert(subscriptions, testsuiteEntry.suite.onTestSubmitted:subscribe(onTestSubmitted))
-	table.insert(subscriptions, testsuiteEntry.suite.onTestSuccess:subscribe(onTestSuccess))
-	table.insert(subscriptions, testsuiteEntry.suite.onTestFailed:subscribe(onTestFailed))
+	table.insert(subscriptions, TestConsole.runner.onTestSubmitted:subscribe(onTestSubmitted))
+	table.insert(subscriptions, TestConsole.runner.onTestSuccess:subscribe(onTestSuccess))
+	table.insert(subscriptions, TestConsole.runner.onTestFailed:subscribe(onTestFailed))
 
 	-- Add child ui elements as fields in the parent object,
 	-- for convenient access
@@ -258,9 +258,9 @@ local function buildTestsuiteUi(testsuiteEntry, isNestedTestsuite)
 			:addTo(entryContentHolder)
 
 		table.insert(subscriptions, resetEvent:subscribe(testUi.onReset))
-		table.insert(subscriptions, testsuiteEntry.suite.onTestStarted:subscribe(testUi.onTestStarted))
-		table.insert(subscriptions, testsuiteEntry.suite.onTestSuccess:subscribe(testUi.onTestSuccess))
-		table.insert(subscriptions, testsuiteEntry.suite.onTestFailed:subscribe(testUi.onTestFailed))
+		table.insert(subscriptions, TestConsole.runner.onTestStarted:subscribe(testUi.onTestStarted))
+		table.insert(subscriptions, TestConsole.runner.onTestSuccess:subscribe(testUi.onTestSuccess))
+		table.insert(subscriptions, TestConsole.runner.onTestFailed:subscribe(testUi.onTestFailed))
 		table.insert(subscriptions, checkbox.onToggled:subscribe(testUi.onParentToggled))
 	end
 
@@ -318,42 +318,24 @@ local function findHolderForTestsuite(testsuite, holder)
 end
 
 local function isSelected(holder, testFunc)
-	if testFunc then
-		for _, child in ipairs(holder.content.children) do
-			if child.entry.func == testFunc then
-				return child.checkbox.checked
-			end
+	for _, child in ipairs(holder.content.children) do
+		if child.entry.func == testFunc then
+			return child.checkbox.checked
 		end
-
-		return false
-	else
-		return holder.header and holder.header.checkbox and holder.header.checkbox.checked
 	end
+
+	return false
 end
 
-local function enumerateSelectedTests(testsuite)
-	local tests = {}
-	local testsuites = {}
+local function enumerateAllTests()
+	return Testsuites:EnumerateTests(true)
+end
 
-	local holder = findHolderForTestsuite(testsuite)
-	if not isSelected(holder) then
-		return tests, testsuites
-	end
-
-	-- Enumerate all selected tests
-	for k, v in pairs(testsuite) do
-		if type(v) == "function" and modApi:stringStartsWith(k, "test_") then
-			if isSelected(holder, v) then
-				table.insert(tests, { name = k, func = v })
-			end
-		elseif type(v) == "table" and Class.instanceOf(v, Tests.Testsuite) then
-			if isSelected(findHolderForTestsuite(v, holder)) then
-				table.insert(testsuites, { name = k, suite = v })
-			end
-		end
-	end
-
-	return tests, testsuites
+local function enumerateSelectedTests()
+	return Testsuites:EnumerateTests(true, function(testsuiteInner, testName, testFn)
+		local holder = findHolderForTestsuite(testsuiteInner)
+		return isSelected(holder, testFn)
+	end)
 end
 
 local function buildTestingConsoleContent(scroll)
@@ -372,7 +354,7 @@ local function buildTestingConsoleButtons(buttonLayout)
 		nil,
 		function()
 			resetEvent:fire()
-			Testsuites:RunAllTests()
+			TestConsole.runner:Start(enumerateAllTests)
 		end
 	)
 	btnRunAll:heightpx(40)
@@ -383,22 +365,23 @@ local function buildTestingConsoleButtons(buttonLayout)
 		nil,
 		function()
 			resetEvent:fire()
-			Testsuites:RunAllTests(enumerateSelectedTests)
+			TestConsole.runner:Start(enumerateSelectedTests)
 		end
 	)
 	btnRunSelected:heightpx(40)
 	btnRunSelected:addTo(buttonLayout)
 
-	btnRunAll.disabled = Testsuites.status ~= Tests.Testsuite.STATUS_COMPLETED
-	btnRunSelected.disabled = Testsuites.status ~= Tests.Testsuite.STATUS_COMPLETED
+	btnRunAll.disabled = TestConsole.runner.status ~= Tests.Runner.STATUS_COMPLETED
+	btnRunSelected.disabled = TestConsole.runner.status ~= Tests.Runner.STATUS_COMPLETED
 
-	table.insert(subscriptions, Testsuites.onTestsuiteStarting:subscribe(function(suite, tests, testsuites)
-		btnRunAll.disabled = true
-		btnRunSelected.disabled = true
-	end))
-	table.insert(subscriptions, Testsuites.onTestsuiteCompleted:subscribe(function(suite, tests, testsuites)
-		btnRunAll.disabled = false
-		btnRunSelected.disabled = false
+	table.insert(subscriptions, TestConsole.runner.onStatusChanged:subscribe(function(suite, oldStatus, newStatus)
+		if newStatus == Tests.Runner.STATUS_COMPLETED then
+			btnRunAll.disabled = false
+			btnRunSelected.disabled = false
+		else
+			btnRunAll.disabled = true
+			btnRunSelected.disabled = true
+		end
 	end))
 end
 
@@ -430,6 +413,8 @@ local function calculateOpenTestingConsoleButtonPosition()
 end
 
 local function createOpenTestingConsoleButton(root)
+	TestConsole.runner = Tests.Runner()
+
 	local button = sdlext.buildButton(
 		GetText("TestingConsole_ToggleButton_Text"),
 		GetText("TestingConsole_ToggleButton_Tooltip"),

--- a/scripts/mod_loader/modui/tests_console.lua
+++ b/scripts/mod_loader/modui/tests_console.lua
@@ -165,7 +165,7 @@ local function buildTestsuiteUi(testsuiteEntry, isNestedTestsuite)
 			DecoButton(),
 			DecoCheckbox(),
 			DecoAlign(4, 2),
-			DecoText(testsuiteEntry.name)
+			DecoText(testsuiteEntry.suite.name or testsuiteEntry.name)
 		})
 		:addTo(entryHeaderHolder)
 	checkbox.checked = true

--- a/scripts/mod_loader/modui/tests_console.lua
+++ b/scripts/mod_loader/modui/tests_console.lua
@@ -77,18 +77,18 @@ local function buildTestUi(testEntry)
 		statusBox.onclicked = Ui.onMouseEnter
 	end
 	entryHolder.onTestStarted = function(entry)
-		if entry.name == testEntry.name then
+		if entry.parent == testEntry.parent and entry.name == testEntry.name then
 			statusBox.decorations[1].bordercolor = TestConsole.colors.border_running
 		end
 	end
 	entryHolder.onTestSuccess = function(entry, resultTable)
-		if entry.name == testEntry.name then
+		if entry.parent == testEntry.parent and entry.name == testEntry.name then
 			statusBox.decorations[1].bordercolor = deco.colors.buttonborder
 			statusBox.decorations[2].surface = deco.surfaces.markTick
 		end
 	end
 	entryHolder.onTestFailed = function(entry, resultTable)
-		if entry.name == testEntry.name then
+		if entry.parent == testEntry.parent and entry.name == testEntry.name then
 			statusBox.decorations[1].bordercolor = deco.colors.buttonborder
 			statusBox.decorations[2].surface = deco.surfaces.markCross
 			statusBox.disabled = false
@@ -214,26 +214,32 @@ local function buildTestsuiteUi(testsuiteEntry, isNestedTestsuite)
 		statusBox.updateStatus()
 	end))
 
-	local onTestSubmitted = function()
-		local old = testsCounter.total
-		testsCounter.total = testsCounter.total + 1
-		statusBox.updateStatus()
+	local onTestSubmitted = function(entry)
+		if testsuiteEntry.suite == entry.parent then
+			local old = testsCounter.total
+			testsCounter.total = testsCounter.total + 1
+			statusBox.updateStatus()
 
-		statusBox.onStatusChanged:fire("total", old, testsCounter.total)
+			statusBox.onStatusChanged:fire("total", old, testsCounter.total)
+		end
 	end
-	local onTestSuccess = function()
-		local old = testsCounter.success
-		testsCounter.success = testsCounter.success + 1
-		statusBox.updateStatus()
+	local onTestSuccess = function(entry)
+		if testsuiteEntry.suite == entry.parent then
+			local old = testsCounter.success
+			testsCounter.success = testsCounter.success + 1
+			statusBox.updateStatus()
 
-		statusBox.onStatusChanged:fire("success", old, testsCounter.success)
+			statusBox.onStatusChanged:fire("success", old, testsCounter.success)
+		end
 	end
-	local onTestFailed = function()
-		local old = testsCounter.failed
-		testsCounter.failed = testsCounter.failed + 1
-		statusBox.updateStatus()
+	local onTestFailed = function(entry)
+		if testsuiteEntry.suite == entry.parent then
+			local old = testsCounter.failed
+			testsCounter.failed = testsCounter.failed + 1
+			statusBox.updateStatus()
 
-		statusBox.onStatusChanged:fire("failed", old, testsCounter.failed)
+			statusBox.onStatusChanged:fire("failed", old, testsCounter.failed)
+		end
 	end
 
 	table.insert(subscriptions, testsuiteEntry.suite.onTestSubmitted:subscribe(onTestSubmitted))

--- a/scripts/mod_loader/tests/__scripts.lua
+++ b/scripts/mod_loader/tests/__scripts.lua
@@ -1,5 +1,6 @@
 local scripts = {
 	"base",
+	"test_runner",
 	"main"
 }
 

--- a/scripts/mod_loader/tests/base.lua
+++ b/scripts/mod_loader/tests/base.lua
@@ -272,9 +272,9 @@ function Tests.Testsuite:EnumerateTests()
 	-- Enumerate all tests
 	for k, v in pairs(self) do
 		if type(v) == "function" and modApi:stringStartsWith(k, "test_") then
-			table.insert(tests, { name = k, func = v })
+			table.insert(tests, { name = k, func = v, parent = self })
 		elseif type(v) == "table" and Class.instanceOf(v, Tests.Testsuite) then
-			table.insert(testsuites, { name = k, suite = v })
+			table.insert(testsuites, { name = k, suite = v, parent = self })
 		end
 	end
 

--- a/scripts/mod_loader/tests/classes.lua
+++ b/scripts/mod_loader/tests/classes.lua
@@ -1,4 +1,5 @@
 local testsuite = Tests.Testsuite()
+testsuite.name = "Classes system tests"
 
 local assertTrue = Assert.True
 local assertFalse = Assert.False

--- a/scripts/mod_loader/tests/event.lua
+++ b/scripts/mod_loader/tests/event.lua
@@ -1,4 +1,5 @@
 local testsuite = Tests.Testsuite()
+testsuite.name = "Events system tests"
 
 local assertTrue = Assert.True
 local assertFalse = Assert.False

--- a/scripts/mod_loader/tests/main.lua
+++ b/scripts/mod_loader/tests/main.lua
@@ -1,21 +1,10 @@
 local rootpath = GetParentPath(...)
 
-local testsuite = Tests.Testsuite()
-function testsuite:RunAllTests(testEnumeratorFn)
-	self.__index.RunAllTests(self, "Root Testsuite", testEnumeratorFn)
-end
+Testsuites = Tests.Testsuite()
 
-testsuite.pawn = require(rootpath.."pawn")
-testsuite.sandbox = require(rootpath.."sandbox")
-testsuite.classes = require(rootpath.."classes")
-testsuite.event = require(rootpath.."event")
-testsuite.modApi = require(rootpath.."modApi")
+Testsuites.pawn = require(rootpath.."pawn")
+Testsuites.sandbox = require(rootpath.."sandbox")
+Testsuites.classes = require(rootpath.."classes")
+Testsuites.event = require(rootpath.."event")
+Testsuites.modApi = require(rootpath.."modApi")
 
---[[
-	Usage, in console while in a mission:
-			Testsuites:RunAllTests()
-		or:
-			Testsuites.name_of_testsuite:RunAllTests()
---]]
-
-Testsuites = testsuite

--- a/scripts/mod_loader/tests/main.lua
+++ b/scripts/mod_loader/tests/main.lua
@@ -5,10 +5,10 @@ local rootpath = GetParentPath(...)
 		Either use the Tests UI visible in test mech scenario when
 		Mod Loader development mode is enabled (recommended),
 		or execute one of the following commands in console while in a mission:
-			Tests.Runner:RunAllTests()
+			Tests.Runner():RunAllTests()
 		or:
-			Tests.Runner:RunAllTests(Testsuites.name_of_testsuite)
-			eg.: Tests.Runner:RunAllTests(Testsuites.pawn)
+			Tests.Runner():RunAllTests(Testsuites.name_of_testsuite)
+			eg.: Tests.Runner():RunAllTests(Testsuites.pawn)
 --]]
 Testsuites = Tests.Testsuite()
 Testsuites.name = "Root Testsuite"

--- a/scripts/mod_loader/tests/main.lua
+++ b/scripts/mod_loader/tests/main.lua
@@ -1,6 +1,7 @@
 local rootpath = GetParentPath(...)
 
 Testsuites = Tests.Testsuite()
+Testsuites.name = "Root Testsuite"
 
 Testsuites.pawn = require(rootpath.."pawn")
 Testsuites.sandbox = require(rootpath.."sandbox")

--- a/scripts/mod_loader/tests/main.lua
+++ b/scripts/mod_loader/tests/main.lua
@@ -1,5 +1,15 @@
 local rootpath = GetParentPath(...)
 
+--[[
+	Usage:
+		Either use the Tests UI visible in test mech scenario when
+		Mod Loader development mode is enabled (recommended),
+		or execute one of the following commands in console while in a mission:
+			Tests.Runner:RunAllTests()
+		or:
+			Tests.Runner:RunAllTests(Testsuites.name_of_testsuite)
+			eg.: Tests.Runner:RunAllTests(Testsuites.pawn)
+--]]
 Testsuites = Tests.Testsuite()
 Testsuites.name = "Root Testsuite"
 
@@ -8,4 +18,3 @@ Testsuites.sandbox = require(rootpath.."sandbox")
 Testsuites.classes = require(rootpath.."classes")
 Testsuites.event = require(rootpath.."event")
 Testsuites.modApi = require(rootpath.."modApi")
-

--- a/scripts/mod_loader/tests/modApi.lua
+++ b/scripts/mod_loader/tests/modApi.lua
@@ -1,4 +1,5 @@
 local testsuite = Tests.Testsuite()
+testsuite.name = "Mod API tests"
 
 function testsuite.test_FileExistsSlashes()
 	Assert.True(modApi:fileExists("./scripts/scripts.lua"))

--- a/scripts/mod_loader/tests/pawn.lua
+++ b/scripts/mod_loader/tests/pawn.lua
@@ -1,4 +1,5 @@
 local testsuite = Tests.Testsuite()
+testsuite.name = "Pawn-related tests"
 
 local assertEquals = Assert.Equals
 local buildPawnTest = Tests.BuildPawnTest

--- a/scripts/mod_loader/tests/sandbox.lua
+++ b/scripts/mod_loader/tests/sandbox.lua
@@ -1,4 +1,5 @@
 local testsuite = Tests.Testsuite()
+testsuite.name = "Script sandbox tests"
 
 local assertEquals = Assert.Equals
 

--- a/scripts/mod_loader/tests/test_runner.lua
+++ b/scripts/mod_loader/tests/test_runner.lua
@@ -27,7 +27,7 @@ end
 --- Convenience function for running directly via console
 function Tests.Runner:RunAllTests(testsuite)
 	testsuite = testsuite or Testsuites
-	self:Start(function() testsuite:EnumerateTests(true) end)
+	self:Start(function() return testsuite:EnumerateTests(true) end)
 end
 
 function Tests.Runner:Start(testEnumeratorFn)

--- a/scripts/mod_loader/tests/test_runner.lua
+++ b/scripts/mod_loader/tests/test_runner.lua
@@ -1,0 +1,163 @@
+Tests.Runner = Class.new()
+
+Tests.Runner.STATUS_READY_TO_RUN_TEST = "READY_TO_RUN_TEST"
+Tests.Runner.STATUS_WAITING_FOR_TEST_FINISH = "WAITING_FOR_TEST_FINISH"
+Tests.Runner.STATUS_READY_TO_PROCESS_RESULTS = "READY_TO_PROCESS_RESULTS"
+Tests.Runner.STATUS_PROCESSING_RESULTS = "PROCESSING_RESULTS"
+Tests.Runner.STATUS_COMPLETED = "COMPLETED"
+Tests.Runner.STATUS_STARTED = "STARTED"
+
+function Tests.Runner:new()
+	self.onTestSubmitted = Event()
+	self.onTestStarted = Event()
+	self.onTestSuccess = Event()
+	self.onTestFailed = Event()
+	self.onStatusChanged = Event()
+
+	self.status = Tests.Runner.STATUS_COMPLETED
+end
+
+function Tests.Runner:ChangeStatus(newStatus)
+	local oldStatus = self.status
+	self.status = newStatus
+
+	self.onStatusChanged:fire(self, oldStatus, newStatus)
+end
+
+function Tests.Runner:Start(testEnumeratorFn)
+	Assert.Equals("function", type(testEnumeratorFn), "Argument #1")
+
+	self:ChangeStatus(Tests.Runner.STATUS_STARTED)
+
+	local tests = testEnumeratorFn()
+
+	-- Shuffle the tests table so that we run tests in random order
+	tests = randomize(tests)
+
+	local resultsHolder = {}
+	self:RunTests(tests, resultsHolder)
+
+	self:ProcessResults(resultsHolder)
+
+	modApi:conditionalHook(
+			function()
+				return self.status == Tests.Runner.STATUS_COMPLETED
+			end,
+			function()
+				DoSaveGame()
+			end
+	)
+
+	self:ChangeStatus(Tests.Runner.STATUS_READY_TO_RUN_TEST)
+end
+
+function Tests.Runner:RunTests(tests, resultsHolder)
+	Assert.Equals("table", type(tests), "Argument #1")
+	Assert.Equals("table", type(resultsHolder), "Argument #2")
+
+	modApi:conditionalHook(
+			function()
+				return self.status == Tests.Runner.STATUS_READY_TO_RUN_TEST
+			end,
+			function()
+				-- Suppress log output so that the results stay somewhat readable
+				local pendingTests = #tests
+				for _, entry in ipairs(tests) do
+					self.onTestSubmitted:fire(entry)
+
+					modApi:conditionalHook(
+							function()
+								return self.status == Tests.Runner.STATUS_READY_TO_RUN_TEST
+							end,
+							function()
+								self:ChangeStatus(Tests.Runner.STATUS_WAITING_FOR_TEST_FINISH)
+								self.onTestStarted:fire(entry)
+
+								local resultTable = {}
+								resultTable.done = false
+								resultTable.name = entry.name
+
+								local ok, result = pcall(function()
+									return entry.func(resultTable)
+								end)
+
+								resultTable.ok = resultTable.ok or ok
+								resultTable.result = resultTable.result or result
+
+								if not resultsHolder[entry.parent] then
+									resultsHolder[entry.parent] = {}
+								end
+
+								table.insert(resultsHolder[entry.parent], resultTable)
+
+								modApi:conditionalHook(
+										function()
+											return not ok or not resultTable.ok or resultTable.result ~= nil or resultTable.done
+										end,
+										function()
+											self:ChangeStatus(Tests.Runner.STATUS_READY_TO_RUN_TEST)
+											if resultTable.ok and resultTable.result == true then
+												self.onTestSuccess:fire(entry, resultTable)
+											else
+												self.onTestFailed:fire(entry, resultTable)
+											end
+											pendingTests = pendingTests - 1
+										end
+								)
+							end
+					)
+				end
+
+				modApi:conditionalHook(
+						function()
+							return pendingTests == 0
+						end,
+						function()
+							self:ChangeStatus(Tests.Runner.STATUS_READY_TO_PROCESS_RESULTS)
+						end
+				)
+			end
+	)
+end
+
+function Tests.Runner:ProcessResults(results)
+	Assert.Equals("table", type(results), "Argument #1")
+
+	modApi:conditionalHook(
+			function()
+				return self.status == Tests.Runner.STATUS_READY_TO_PROCESS_RESULTS
+			end,
+			function()
+				self:ChangeStatus(Tests.Runner.STATUS_PROCESSING_RESULTS)
+
+				local failedTests = {}
+				local failedCount = 0
+				for testsuite, resultTable in pairs(results) do
+					failedTests[testsuite] = {}
+					local t = failedTests[testsuite]
+
+					for _, entry in ipairs(resultTable) do
+						-- 'result' is also used to hold error information, so compare it to true
+						if not (entry.ok and entry.result == true) then
+							failedCount = failedCount + 1
+							table.insert(t, entry)
+						end
+					end
+				end
+
+				if #results > 0 then
+					LOGF("Tests summary: passed %s / %s tests", #results - failedCount, #results)
+
+					for testsuite, resultTable in pairs(failedTests) do
+						if #resultTable > 0 then
+							for _, entry in ipairs(resultTable) do
+								LOGF("%s.%s: %s", entry.parent.name, entry.name, entry.result)
+							end
+						end
+					end
+				end
+
+				self:ChangeStatus(Tests.Runner.STATUS_COMPLETED)
+			end
+	)
+end

--- a/scripts/mod_loader/tests/test_runner.lua
+++ b/scripts/mod_loader/tests/test_runner.lua
@@ -138,10 +138,12 @@ function Tests.Runner:ProcessResults(results)
 
 				local failedTests = {}
 				local failedCount = 0
+				local totalCount = 0
 				for testsuite, resultTable in pairs(results) do
 					failedTests[testsuite] = {}
 					local t = failedTests[testsuite]
 
+					totalCount = totalCount + #resultTable
 					for _, entry in ipairs(resultTable) do
 						-- 'result' is also used to hold error information, so compare it to true
 						if not (entry.ok and entry.result == true) then
@@ -151,14 +153,12 @@ function Tests.Runner:ProcessResults(results)
 					end
 				end
 
-				if #results > 0 then
-					LOGF("Tests summary: passed %s / %s tests", #results - failedCount, #results)
+				if totalCount > 0 then
+					LOGF("Tests summary: passed %s / %s tests", totalCount - failedCount, totalCount)
 
-					for testsuite, resultTable in pairs(failedTests) do
-						if #resultTable > 0 then
-							for _, entry in ipairs(resultTable) do
-								LOGF("%s.%s: %s", entry.parent.name, entry.name, entry.result)
-							end
+					for _, resultTable in pairs(failedTests) do
+						for _, entry in ipairs(resultTable) do
+							LOGF("%s.%s: %s", entry.parent.name, entry.name, entry.result)
 						end
 					end
 				end

--- a/scripts/mod_loader/tests/test_runner.lua
+++ b/scripts/mod_loader/tests/test_runner.lua
@@ -24,6 +24,12 @@ function Tests.Runner:ChangeStatus(newStatus)
 	self.onStatusChanged:fire(self, oldStatus, newStatus)
 end
 
+--- Convenience function for running directly via console
+function Tests.Runner:RunAllTests(testsuite)
+	testsuite = testsuite or Testsuites
+	self:Start(function() testsuite:EnumerateTests(true) end)
+end
+
 function Tests.Runner:Start(testEnumeratorFn)
 	Assert.Equals("function", type(testEnumeratorFn), "Argument #1")
 


### PR DESCRIPTION
Inspired by #49 - primarily fixes the console so that running only selected tests is less cumbersome.
Also cleans up testing console code a bit, demotes testsuites to the role of simple containers, and allows them to optionally override their displayed name.