### PR TITLE
Added PawnFocused and PawnUnfocuesed Hooks and logic to fire them

### DIFF
--- a/scripts/mod_loader/altered/skills.lua
+++ b/scripts/mod_loader/altered/skills.lua
@@ -113,6 +113,7 @@ end
 
 local focusedPawnLast = nil
 local focusedPawnCurrent = nil
+local selectedPawnIdLast = nil
 local function buildGetIsPortraitOverride(pawn)
 	local originalFn = pawn.GetIsPortrait
 
@@ -124,14 +125,19 @@ local function buildGetIsPortraitOverride(pawn)
 end
 
 sdlext.addFrameDrawnHook(function()
-	if focusedPawnLast and focusedPawnCurrent ~= focusedPawnLast then
-		modApi:firePawnUnfocusedHooks(focusedPawnLast)
+	local selectedPawnIdCurrent = Board and Board:GetSelectedPawnId() or nil
+
+	if focusedPawnCurrent ~= focusedPawnLast or selectedPawnIdCurrent ~= selectedPawnIdLast then
+		if focusedPawnLast then
+			modApi:firePawnUnfocusedHooks(focusedPawnLast)
+		end
+
+		if focusedPawnCurrent then
+			modApi:firePawnFocusedHooks(focusedPawnCurrent)
+		end
 	end
 
-	if focusedPawnCurrent and focusedPawnCurrent ~= focusedPawnLast then
-		modApi:firePawnFocusedHooks(focusedPawnCurrent)
-	end
-
+	selectedPawnIdLast = selectedPawnIdCurrent
 	focusedPawnLast = focusedPawnCurrent
 	focusedPawnCurrent = nil
 end)

--- a/scripts/mod_loader/modapi/board.lua
+++ b/scripts/mod_loader/modapi/board.lua
@@ -94,3 +94,27 @@ BoardClass.IsHighlighted = function(self, loc)
 	
 	return loc == mouseTile()
 end
+
+BoardClass.GetSelectedPawn = function(self)
+	Assert.Equals("userdata", type(self), "Argument #0")
+	
+	local pawns = Board:GetPawns(TEAM_ANY)
+	for i = 1, pawns:size() do
+		local pawn = Board:GetPawn(pawns:index(i))
+		if pawn and pawn:IsSelected() then
+			return pawn
+		end
+	end
+	
+	return nil
+end
+
+BoardClass.GetSelectedPawnId = function(self)
+	local selectedPawn = self:GetSelectedPawn()
+	
+	if selectedPawn then
+		return selectedPawn:GetId()
+	end
+	
+	return nil
+end

--- a/scripts/mod_loader/modapi/hooks.lua
+++ b/scripts/mod_loader/modapi/hooks.lua
@@ -71,6 +71,8 @@ local hooks = {
 	"SaveDataUpdated",
 	"TipImageShown",
 	"TipImageHidden",
+	"PawnFocused",
+	"PawnUnfocused",
 }
 
 for _, name in ipairs(hooks) do


### PR DESCRIPTION
'Focused' here means when a pawn is either hovered or selected; and the game draws the ui for the pawn's pilot, traits and weapons at the bottom left of the screen, during a mission (including test mech scenario).