### PR TITLE
Improvements uitooltip

### DIFF
--- a/scripts/mod_loader/ui/widgets/boxlayout.lua
+++ b/scripts/mod_loader/ui/widgets/boxlayout.lua
@@ -105,7 +105,6 @@ function UiBoxLayout:relayout()
 				end
 
 				child.x = nextOffset
-				nextOffset = nextOffset + child.w + self.gapHorizontal
 			elseif self:isVBox() then
 				if not child.alignH or child.alignH == "left" then
 					child.x = 0
@@ -116,13 +115,18 @@ function UiBoxLayout:relayout()
 				end
 
 				child.y = nextOffset
-				nextOffset = nextOffset + child.h + self.gapVertical
 			end
 			
 			child.screenx = self.screenx + self.padl - self.dx + child.x
 			child.screeny = self.screeny + self.padt - self.dy + child.y
 			
 			child:relayout()
+			
+			if self:isHBox() then
+				nextOffset = nextOffset + child.w + self.gapHorizontal
+			elseif self:isVBox() then
+				nextOffset = nextOffset + child.h + self.gapVertical
+			end
 			
 			child.rect.x = child.screenx
 			child.rect.y = child.screeny

--- a/scripts/mod_loader/ui/widgets/tooltip.lua
+++ b/scripts/mod_loader/ui/widgets/tooltip.lua
@@ -36,7 +36,19 @@ local function computeAlignedPos(self, widget, screen, horizontal)
 	end
 end
 
-function UiTooltip:draw(screen)
+function UiTooltip:updateText()
+	if self.text ~= self.root.tooltip then
+		self.w = 0
+		self:setText(self.root.tooltip)
+		self.w = self:maxChildSize() + self.padl + self.padr
+	end
+
+	self.visible = self.text and self.text ~= ""
+end
+
+function UiTooltip:relayout()
+	local screen = sdl.screen()
+
 	if modApi.floatyTooltips then
 		-- Attach to the mouse cursor
 		local x = sdl.mouse.x()
@@ -96,25 +108,6 @@ function UiTooltip:draw(screen)
 		self.screeny = self.y
 	end
 
-	UiWrappedText.draw(self, screen)
-
-	-- Update *after* our first call to draw()
-	-- otherwise we get nasty flickering, since apparently
-	-- the ui element is not being updated fast enough before
-	-- it gets drawn?
-	self.laidOut = true
 	self:updateText()
-end
-
-function UiTooltip:updateText()
-	if self.text ~= self.root.tooltip then
-		self.w = 0
-		self:setText(self.root.tooltip)
-		self.w = self:maxChildSize() + self.padl + self.padr
-
-		self:relayout()
-		self.laidOut = false
-	end
-
-	self.visible = self.laidOut and self.text and self.text ~= ""
+	UiWrappedText.relayout(self)
 end

--- a/scripts/mod_loader/ui/widgets/weightlayout.lua
+++ b/scripts/mod_loader/ui/widgets/weightlayout.lua
@@ -129,17 +129,21 @@ function UiWeightLayout:relayout()
 			if self.horizontal then
 				nextX = nextX + child.w + self.gapHorizontal
 				currentMaxSize = math.max(currentMaxSize, child.h)
-				self.innerWidth = math.min(self.w, self.innerWidth + child.w + self.gapHorizontal)
 			else
 				nextY = nextY + child.h + self.gapVertical
 				currentMaxSize = math.max(currentMaxSize, child.w)
-				self.innerHeight = math.min(self.h, self.innerHeight + child.h + self.gapVertical)
 			end
 
 			child.screenx = self.screenx + self.padl - self.dx + child.x
 			child.screeny = self.screeny + self.padt - self.dy + child.y
 
 			child:relayout()
+			
+			if self.horizontal then
+				self.innerWidth = math.min(self.w, self.innerWidth + child.w + self.gapHorizontal)
+			else
+				self.innerHeight = math.min(self.h, self.innerHeight + child.h + self.gapVertical)
+			end
 
 			child.rect.x = child.screenx
 			child.rect.y = child.screeny


### PR DESCRIPTION
Changes `UiBoxLayout`'s and `UiWeightLayout`'s relayout functions to relayout to children before using the childrens' size for calculations. This will ensure parents set their own size correctly all the way to the top when a very nested child element changes in size.

Along with those changes, `UiTooltip` has also beeen changed to update text in `relayout` instead of `draw`. This change makes tooltips appear the moment an element with a tooltip is hovered, and the text no longer flickers.