### PR TITLE
Added events related to initializing and loading mods

### DIFF
--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -6,7 +6,11 @@ modApi = modApi or {}
 modApi.events = {}
 
 local t = modApi.events
+t.onModMetadataDone = Event()
+t.onModsMetadataDone = Event()
+t.onModInitialized = Event()
 t.onModsInitialized = Event()
+t.onModLoaded = Event()
 t.onModsLoaded = Event()
 t.onModsFirstLoaded = Event()
 t.onInitialLoadingFinished = Event()

--- a/scripts/mod_loader/mod_loader.lua
+++ b/scripts/mod_loader/mod_loader.lua
@@ -69,14 +69,23 @@ function mod_loader:init()
 		modApi:setCurrentMod(id)
 		self:initMetadata(id)
 		i = i + 1
+		modApi.events.onModMetadataDone:dispatch(id)
 	end
+
+	modApi.events.onModMetadataDone:unsubscribeAll()
+
+	modApi.events.onModsMetadataDone:dispatch()
+	modApi.events.onModsMetadataDone:unsubscribeAll()
 
 	local orderedMods = self:orderMods(self:getModConfig(), self:getSavedModOrder())
 	for i, id in ipairs(orderedMods) do
 		modApi:setCurrentMod(id)
 		self:initMod(id)
+		modApi.events.onModInitialized:dispatch(id)
 	end
-	
+
+	modApi.events.onModInitialized:unsubscribeAll()
+
 	Assert.Traceback = true
 	modApi:setCurrentMod(nil)
 
@@ -542,6 +551,7 @@ function mod_loader:loadModContent(mod_options,savedOrder)
 					mod.name,
 					id
 				))
+				modApi.events.onModLoaded:dispatch(id)
 			else
 				mod.installed = false
 				mod.error = err


### PR DESCRIPTION
Added some events that can be useful for executing code at specific times while are initializing and loading:
- `onModMetadataDone` -- fired each time a mod has finished their metadata function
- `onModsMetadataDone` -- fired after all metadata functions have been run
- `onModInitialized` -- fired each time a mod has finished initializing
- `onModLoaded` -- fired each time a mod has finished loading