### PR TITLE
Fixed window show/hide events from being dispatched one frame too late

### DIFF
--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -19,6 +19,7 @@ t.onUiRootCreating = Event()
 t.onUiRootCreated = Event()
 t.onGameWindowResized = Event()
 t.onConsoleToggled = Event()
+t.onFrameDrawStart = Event()
 t.onFrameDrawn = Event()
 t.onWindowVisible = Event()
 

--- a/scripts/mod_loader/modui/root.lua
+++ b/scripts/mod_loader/modui/root.lua
@@ -309,6 +309,8 @@ MOD_API_DRAW_HOOK = sdl.drawHook(function(screen)
 		modApi.events.onWindowVisible:dispatch(screen, wx, wy, ww, wh)
 	end
 
+	modApi.events.onFrameDrawStart:dispatch(screen)
+
 	uiRoot:draw(screen)
 
 	modApi.events.onFrameDrawn:dispatch(screen)

--- a/scripts/mod_loader/modui/windows.lua
+++ b/scripts/mod_loader/modui/windows.lua
@@ -6,12 +6,16 @@ local Window = {}
 CreateClass(Window)
 
 function Window:show(id)
+	if self.visible then return end
+
 	self.visible = true
 	visibleWindows[id] = self
 	self.event_show:dispatch()
 end
 
 function Window:hide(id)
+	if not self.visible then return end
+
 	self.visible = false
 	visibleWindows[id] = nil
 	self.event_hide:dispatch()
@@ -105,7 +109,7 @@ function GetText(id, ...)
 	return oldGetText(id, ...)
 end
 
-modApi.events.onFrameDrawn:subscribe(function()
+modApi.events.onFrameDrawStart:subscribe(function()
 
 	for id, window in pairs(visibleWindows) do
 		if not showWindows[id] then
@@ -115,9 +119,7 @@ modApi.events.onFrameDrawn:subscribe(function()
 
 	if next(showWindows) ~= nil then
 		for id, window in pairs(showWindows) do
-			if not window.visible then
-				window:show(id)
-			end
+			window:show(id)
 		end
 
 		showWindows = {}


### PR DESCRIPTION
Added the event `modApi.events.onFrameDrawStart`

Using this event, subscribers can be notified of the windows being shown/hidden before modded ui is drawn, and update visibility and/or state of their ui element accordingly.