### PR TITLE
Added events for when a unit's Status Tooltip is shown/hidden

### DIFF
--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -72,6 +72,8 @@ t.onNewGameWindowShown = Event()
 t.onNewGameWindowHidden = Event()
 t.onAbandonTimelineWindowShown = Event()
 t.onAbandonTimelineWindowHidden = Event()
+t.onStatusTooltipWindowShown = Event()
+t.onStatusTooltipWindowHidden = Event()
 
 t.onShiftToggled = Event()
 t.onAltToggled = Event()

--- a/scripts/mod_loader/modui/windows.lua
+++ b/scripts/mod_loader/modui/windows.lua
@@ -94,6 +94,10 @@ local windows = {
 		event_show = modApi.events.onAbandonTimelineWindowShown,
 		event_hide = modApi.events.onAbandonTimelineWindowHidden
 	},
+	Unit_Status_Title = Window:new{
+		event_show = modApi.events.onStatusTooltipWindowShown,
+		event_hide = modApi.events.onStatusTooltipWindowHidden,
+	},
 }
 
 sdlext.isEscapeMenuWindowVisible = buildIsWindowVisibleFunction(windows.Escape_Title)
@@ -111,6 +115,7 @@ sdlext.isDeleteProfileConfirmationWindowVisible = buildIsWindowVisibleFunction(w
 sdlext.isStatisticsWindowVisible = buildIsWindowVisibleFunction(windows.Stats_Header)
 sdlext.isNewGameWindowVisible = buildIsWindowVisibleFunction(windows.NewGame_Confirm_Title)
 sdlext.isAbandonTimelineWindowVisible = buildIsWindowVisibleFunction(windows.Abandon_Confirm_Title)
+sdlext.isStatusTooltipWindowVisible = buildIsWindowVisibleFunction(windows.Unit_Status_Title)
 
 local oldGetText = GetText
 function GetText(id, ...)


### PR DESCRIPTION
Added events:
`modApi.events.onStatusTooltipWindowShown`
`modApi.events.onStatusTooltipWindowHidden`

Added function:
`sdlext.isStatusTooltipWindowVisible`