### PR TITLE
Change focused pawn and tipskill to update before modded ui is drawn

### DIFF
--- a/scripts/mod_loader/altered/skills.lua
+++ b/scripts/mod_loader/altered/skills.lua
@@ -90,7 +90,7 @@ local function buildGetTipDamageOverride(skill)
 	end
 end
 
-modApi.events.onFrameDrawn:subscribe(function()
+modApi.events.onFrameDrawStart:subscribe(function()
 	if tipSkillLast and tipSkillCurrent ~= tipSkillLast then
 		modApi:fireTipImageHiddenHooks(tipSkillLast)
 	end
@@ -149,7 +149,7 @@ local function buildGetIsPortraitOverride(pawn)
 	end
 end
 
-modApi.events.onFrameDrawn:subscribe(function()
+modApi.events.onFrameDrawStart:subscribe(function()
 	local selectedPawnIdCurrent = Board and Board:GetSelectedPawnId() or nil
 
 	if focusedPawnCurrent ~= focusedPawnLast or selectedPawnIdCurrent ~= selectedPawnIdLast then


### PR DESCRIPTION
By running the update code before modded ui is drawn, mods can draw over the vanilla ui immediately as it is shown, instead of one frame too late.