### PR TITLE
Made scrolling of UiScrollArea smoother

### DIFF
--- a/scripts/mod_loader/modui/pilot_arrange.lua
+++ b/scripts/mod_loader/modui/pilot_arrange.lua
@@ -181,9 +181,8 @@ local function buildPilotButton(pilotId, placeholder)
 	end
 
 	button.dragWheel = function(self, mx, my, y)
-		local offset = pilotsLayout.parent:computeOffset(y)
-
 		pilotsLayout.parent:wheel(mx, my, y)
+		local offset = pilotsLayout.parent.dyTarget - pilotsLayout.parent.dy
 
 		self:processDropTargets(mx, my + offset)
 


### PR DESCRIPTION
Added variables:
- dyTarget: dy (which is the scroll offset of the ui element), will attempt to close in towards dyTarget each frame.
- scrollSpeed: The number of pixels each scroll click will yield.
- scrollOvershoot: The number of pixels we can overshoot the top/bottom of the ui element. It will always bounce back to the content of the ui element once scrolling stops.
- scrollChangefactor: The rate at which dy approaches dyTarget by the formula: dy = dy * (1-factor) + dyTarget * factor. So factor 0 will never change anything, while factor 1 will instantly change dy to dyTarget.