### PR TITLE
Rework UI system

### DIFF
--- a/scripts/mod_loader/modui/dialog_helper.lua
+++ b/scripts/mod_loader/modui/dialog_helper.lua
@@ -402,13 +402,11 @@ function sdlext.buildDropDownButton(text, tooltip, choices, choiceHandler)
 				DecoDropDown()
 			})
 
-	btn.destroyDropDown = function(self)
-		UiDropDown.destroyDropDown(self)
-
+	btn.optionSelected:subscribe(function(self, oldChoice, oldValue)
 		if choiceHandler then
 			choiceHandler(self.value)
 		end
-	end
+	end)
 
 	if tooltip and tooltip ~= "" then
 		btn:settooltip(tooltip)

--- a/scripts/mod_loader/modui/dialog_helper.lua
+++ b/scripts/mod_loader/modui/dialog_helper.lua
@@ -402,9 +402,9 @@ function sdlext.buildDropDownButton(text, tooltip, choices, choiceHandler)
 				DecoDropDown()
 			})
 
-	btn.optionSelected:subscribe(function(self, oldChoice, oldValue)
+	btn.optionSelected:subscribe(function(oldChoice, oldValue)
 		if choiceHandler then
-			choiceHandler(self.value)
+			choiceHandler(btn.value)
 		end
 	end)
 

--- a/scripts/mod_loader/modui/mod_configuration.lua
+++ b/scripts/mod_loader/modui/mod_configuration.lua
@@ -186,8 +186,6 @@ local function clickConfiguration(self, button)
 			closeDropdown(self)
 		end
 		
-		scrollContent.parent:relayout()
-		
 		return true
 	end
 	

--- a/scripts/mod_loader/modui/mod_configuration.lua
+++ b/scripts/mod_loader/modui/mod_configuration.lua
@@ -263,10 +263,9 @@ local function buildOptionEntries(mod)
 					DecoDropDown()
 				})
 				
-			optionEntry.destroyDropDown = function(self)
-				UiDropDown.destroyDropDown(self)
+			optionEntry.optionSelected:subscribe(function(self, oldChoice, oldValue)
 				opt_editable.value = self.value
-			end
+			end)
 		end
 		
 		optionEntry

--- a/scripts/mod_loader/modui/mod_configuration.lua
+++ b/scripts/mod_loader/modui/mod_configuration.lua
@@ -263,8 +263,8 @@ local function buildOptionEntries(mod)
 					DecoDropDown()
 				})
 				
-			optionEntry.optionSelected:subscribe(function(self, oldChoice, oldValue)
-				opt_editable.value = self.value
+			optionEntry.optionSelected:subscribe(function(oldChoice, oldValue)
+				opt_editable.value = optionEntry.value
 			end)
 		end
 		

--- a/scripts/mod_loader/modui/modloader_configuration.lua
+++ b/scripts/mod_loader/modui/modloader_configuration.lua
@@ -133,7 +133,6 @@ local function createUi()
 		collapse.onclicked = function(self, button)
 			if button == 1 then
 				entryBoxHolder.content.visible = not self.checked
-				entryBoxHolder:relayout()
 			end
 
 			return true

--- a/scripts/mod_loader/modui/palette_arrange.lua
+++ b/scripts/mod_loader/modui/palette_arrange.lua
@@ -164,8 +164,6 @@ local function hoverAtIndex(self, new_placeholderIndex)
 
 	local lock = not unlockedSquads[new_placeholderIndex]
 	self:displayPaletteLocked(lock)
-
-	content:relayout()
 end
 
 local function displayPaletteLocked(self, displayLocked)

--- a/scripts/mod_loader/modui/palette_arrange.lua
+++ b/scripts/mod_loader/modui/palette_arrange.lua
@@ -157,10 +157,6 @@ local function displayPaletteLocked(self, displayLocked)
 	end
 end
 
-local function updateTooltipState(self)
-	self.root:settooltip(self.tooltip, nil, self.pressed)
-end
-
 local function buildPaletteFrameContent(scroll)
 	local screen = sdl.screen()
 
@@ -240,7 +236,6 @@ local function buildPaletteFrameContent(scroll)
 		button.deco_lock = deco_lock
 		button.displayPaletteLocked = displayPaletteLocked
 		button.hoverAtIndex = hoverAtIndex
-		button.updateTooltipState = updateTooltipState
 
 		if not unlockedSquads[i] then
 			button:displayPaletteLocked(true)

--- a/scripts/mod_loader/modui/palette_arrange.lua
+++ b/scripts/mod_loader/modui/palette_arrange.lua
@@ -121,32 +121,12 @@ local function uiSetDraggable(ui)
 	ui.getDropTargets = function(self)
 		if self.dropTargets == nil then
 			self.dropTargets = {}
-			for _, target in ipairs(content.children) do
+			for i = 2, #content.children do
+				local target = content.children[i]
 				table.insert(self.dropTargets, target)
 			end
 		end
 		return self.dropTargets
-	end
-
-	ui.dragMove = function(self, mx, my)
-		if self.parent ~= self.root.draggableUi then return end
-		UiDraggable.dragMove(self, mx, my)
-
-		for i = PALETTE_INDEX_FIRST_MOVABLE, #content.children do
-			local hoveredButton = content.children[i]
-			if rect_contains(hoveredButton.rect, mx, my) then
-				if hoveredButton ~= placeholder then
-					self:hoverAtIndex(i)
-				end
-
-				return
-			end
-		end
-
-		-- if we get this far, we are not hovering any of the buttons
-		if content.children[#content.children] ~= placeholder then
-			self:hoverAtIndex(#content.children)
-		end
 	end
 end
 

--- a/scripts/mod_loader/modui/palette_arrange.lua
+++ b/scripts/mod_loader/modui/palette_arrange.lua
@@ -106,8 +106,7 @@ local function buildContractedDeco(marginx, marginy, uiDeco, ...)
 end
 
 local function uiSetDraggable(ui)
-	ui:registerDragMove()
-	ui:registerDragPlaceholder(placeholder)
+	ui:registerDragDropList(placeholder)
 
 	-- Called each time we hover over an element that's been registered as valid drop target
 	ui.onDraggableEntered = function(self, draggable, target)
@@ -121,7 +120,7 @@ local function uiSetDraggable(ui)
 	ui.getDropTargets = function(self)
 		if self.dropTargets == nil then
 			self.dropTargets = {}
-			for i = 2, #content.children do
+			for i = PALETTE_INDEX_FIRST_MOVABLE, #content.children do
 				local target = content.children[i]
 				table.insert(self.dropTargets, target)
 			end

--- a/scripts/mod_loader/modui/pilot_arrange.lua
+++ b/scripts/mod_loader/modui/pilot_arrange.lua
@@ -68,6 +68,10 @@ local function getOrCreatePilotSurface(pilotId)
 	end
 end
 
+local function updateTooltipState(self)
+	self.root:settooltip(self.tooltip, GetText(self.tooltip_title), self.pressed)
+end
+
 local hangarDecorations = nil
 local portraitSize = 122 + 8
 local function buildHangarBackdrop()
@@ -106,6 +110,7 @@ local function buildPilotButton(pilotId, placeholder)
 		:widthpx(portraitSize):heightpx(portraitSize)
 		:decorate(decorations)
 	button.pilotId = pilotId
+	button.updateTooltipState = updateTooltipState
 
 	-- only show tooltip text if the pilot is unlocked
 	if unlocked then
@@ -114,86 +119,29 @@ local function buildPilotButton(pilotId, placeholder)
 		if not desc or desc == "" then
 			desc = "Hangar_NoAbility"
 		end
-		button:settooltip(string.format("%s\n\n%s", GetText(pilot.Name), GetText(desc)))
+		button:settooltip(GetText(desc), GetText(pilot.Name))
 	end
 
 	button:registerDragMove()
+	button:registerDragPlaceholder(placeholder)
 
 	-- Called each time we hover over an element that's been registered as valid drop target
 	button.onDraggableEntered = function(self, draggable, target)
-		-- The target elements get shifted around when dragged over, so they quickly flash
-		-- on and off due to being hovered. Prevent that.
-		target.hovered = false
-
 		if self == draggable then
 			local targetIndex = list_indexof(pilotsLayout.children, target)
 			placeholder:detach()
 			pilotsLayout:add(placeholder, targetIndex)
-
-			pilotsLayout:relayout()
 		end
 	end
 
-	button.startDrag = function(self, mx, my, btn)
-		if btn ~= 1 then
-			return
+	button.getDropTargets = function(self)
+		if self.dropTargets == nil then
+			self.dropTargets = {}
+			for _, target in ipairs(pilotsLayout.children) do
+				table.insert(self.dropTargets, target)
+			end
 		end
-
-		UiDraggable.startDrag(self, mx, my, btn)
-
-		-- Put the dragged pilot button in the root UI element, so that we can move it freely
-		-- without affecting the other buttons' layout.
-		-- Correct position, since when moving an element between parents, its position is not
-		-- automatically translated.
-		local index = list_indexof(pilotsLayout.children, self)
-		self:detach()
-		pilotsLayout:add(placeholder, index)
-
-		self:addTo(sdlext.getUiRoot())
-		self.x = self.screenx
-		self.y = self.screeny
-		self:bringToTop()
-
-		for _, child in ipairs(pilotsLayout.children) do
-			button:registerDropTarget(child)
-		end
-
-		pilotsLayout:relayout()
-	end
-
-	button.stopDrag = function(self, mx, my, btn)
-		if btn ~= 1 or not self.dragMoving then
-			return
-		end
-
-		UiDraggable.stopDrag(self, mx, my, btn)
-
-		-- Put the dragged pilot back into the layout. No need to correct position here,
-		-- since the layout's logic will do that automatically
-		local index = list_indexof(pilotsLayout.children, placeholder)
-		self:detach()
-		placeholder:detach()
-		pilotsLayout:add(self, index)
-
-		self:clearDropTargets()
-
-		pilotsLayout:relayout()
-	end
-
-	button.dragWheel = function(self, mx, my, y)
-		pilotsLayout.parent:wheel(mx, my, y)
-		local offset = pilotsLayout.parent.dyTarget - pilotsLayout.parent.dy
-
-		self:processDropTargets(mx, my + offset)
-
-		-- Scrollarea's wheel() function calls back to children's mousemove(), which
-		-- updates hovered states. We need to correct that here.
-		if self.root.hoveredchild ~= nil then
-			self.root.hoveredchild.hovered = false
-		end
-
-		self.root.hoveredchild = self
-		self.hovered = true
+		return self.dropTargets
 	end
 
 	return button

--- a/scripts/mod_loader/modui/pilot_arrange.lua
+++ b/scripts/mod_loader/modui/pilot_arrange.lua
@@ -122,8 +122,7 @@ local function buildPilotButton(pilotId, placeholder)
 		button:settooltip(GetText(desc), GetText(pilot.Name))
 	end
 
-	button:registerDragMove()
-	button:registerDragPlaceholder(placeholder)
+	button:registerDragDropList(placeholder)
 
 	-- Called each time we hover over an element that's been registered as valid drop target
 	button.onDraggableEntered = function(self, draggable, target)

--- a/scripts/mod_loader/modui/pilot_arrange.lua
+++ b/scripts/mod_loader/modui/pilot_arrange.lua
@@ -68,10 +68,6 @@ local function getOrCreatePilotSurface(pilotId)
 	end
 end
 
-local function updateTooltipState(self)
-	self.root:settooltip(self.tooltip, self.tooltip_title, self.pressed)
-end
-
 local hangarDecorations = nil
 local portraitSize = 122 + 8
 local function buildHangarBackdrop()
@@ -110,7 +106,6 @@ local function buildPilotButton(pilotId, placeholder)
 		:widthpx(portraitSize):heightpx(portraitSize)
 		:decorate(decorations)
 	button.pilotId = pilotId
-	button.updateTooltipState = updateTooltipState
 
 	-- only show tooltip text if the pilot is unlocked
 	if unlocked then

--- a/scripts/mod_loader/modui/pilot_arrange.lua
+++ b/scripts/mod_loader/modui/pilot_arrange.lua
@@ -213,8 +213,6 @@ local function btnDefaultHandlerFn()
 		return indexA < indexB
 	end)
 
-	pilotsLayout:relayout()
-
 	return true
 end
 
@@ -227,8 +225,6 @@ local function btnRandomHandlerFn()
 	table.sort(pilotsLayout.children, function(a, b)
 		return order[a] < order[b]
 	end)
-
-	pilotsLayout:relayout()
 
 	return true
 end

--- a/scripts/mod_loader/modui/pilot_arrange.lua
+++ b/scripts/mod_loader/modui/pilot_arrange.lua
@@ -69,7 +69,7 @@ local function getOrCreatePilotSurface(pilotId)
 end
 
 local function updateTooltipState(self)
-	self.root:settooltip(self.tooltip, GetText(self.tooltip_title), self.pressed)
+	self.root:settooltip(self.tooltip, self.tooltip_title, self.pressed)
 end
 
 local hangarDecorations = nil

--- a/scripts/mod_loader/modui/weapon_deck_selector.lua
+++ b/scripts/mod_loader/modui/weapon_deck_selector.lua
@@ -307,7 +307,6 @@ local function buildClassHolder(classHeaderText)
 
 	sdlext.addButtonSoundHandlers(collapseButton, function()
 		weaponsHolder.visible = not collapseButton.checked
-		entryBoxHolder:relayout()
 	end)
 
 	return entryBoxHolder

--- a/scripts/mod_loader/sdlext/extensions.lua
+++ b/scripts/mod_loader/sdlext/extensions.lua
@@ -232,10 +232,10 @@ function rect_contains(...)
 end
 
 function rect_intersects(r1, r2)
-	return not (r2.x > r1.x + r1.w or
-	            r2.x + r2.w < r1.x or
-	            r2.y > r1.y + r1.h or
-	            r2.y + r2.h < r1.y)
+	return not (r2.x >= r1.x + r1.w or
+	            r2.x + r2.w <= r1.x or
+	            r2.y >= r1.y + r1.h or
+	            r2.y + r2.h <= r1.y)
 end
 
 --[[

--- a/scripts/mod_loader/sdlext/extensions.lua
+++ b/scripts/mod_loader/sdlext/extensions.lua
@@ -205,9 +205,9 @@ function drawtri_br(screen, color, rect)
 end
 
 local function rect_contains0(x, y, w, h, px, py)
-	return px > x     and
-	       px < x + w and
-	       py > y     and
+	return px >= x     and
+	       px < x + w  and
+	       py >= y     and
 	       py < y + h
 end
 
@@ -218,7 +218,7 @@ end
 --]]
 function rect_contains(...)
 	local a = {...}
-	assert(#a == 3 or #a == 6, "Invalid arguments")
+	Assert.True(#a == 3 or #a == 6, "Expected 3 or 6 arguments, but got " .. #a)
 
 	if #a == 3 then
 		return rect_contains0(

--- a/scripts/mod_loader/tests/modApi.lua
+++ b/scripts/mod_loader/tests/modApi.lua
@@ -93,6 +93,117 @@ function testsuite.io.test_GetFileNameEmpty()
 end
 
 -- ///////////////////////////////////////////////////////////////
+-- Geometry Tests
+testsuite.geometry = Tests.Testsuite()
+testsuite.geometry.name = "Geometry"
+
+function testsuite.geometry.test_RectIntersectLeftEdge()
+	local r1 = sdl.rect(10, 10, 10, 10)
+	local r2 = sdl.rect(0,  10, 10, 10)
+	Assert.False(rect_intersects(r1, r2))
+	return true
+end
+
+function testsuite.geometry.test_RectIntersectTopEdge()
+	local r1 = sdl.rect(10, 10, 10, 10)
+	local r2 = sdl.rect(10, 0,  10, 10)
+	Assert.False(rect_intersects(r1, r2))
+	return true
+end
+
+function testsuite.geometry.test_RectIntersectRightEdge()
+	local r1 = sdl.rect(10, 10, 10, 10)
+	local r2 = sdl.rect(20, 10, 10, 10)
+	Assert.False(rect_intersects(r1, r2))
+	return true
+end
+
+function testsuite.geometry.test_RectIntersectBottomEdge()
+	local r1 = sdl.rect(10, 10, 10, 10)
+	local r2 = sdl.rect(10, 20, 10, 10)
+	Assert.False(rect_intersects(r1, r2))
+	return true
+end
+
+function testsuite.geometry.test_RectIntersectComplete()
+	local r1 = sdl.rect(10, 10, 10, 10)
+	local r2 = sdl.rect(12, 12, 6, 6)
+	Assert.True(rect_intersects(r1, r2))
+	return true
+end
+
+function testsuite.geometry.test_RectIntersectNone()
+	local r1 = sdl.rect(10, 10, 10, 10)
+	local r2 = sdl.rect(25, 10, 10, 10)
+	Assert.False(rect_intersects(r1, r2))
+	return true
+end
+
+function testsuite.geometry.test_RectIntersectPartialLeft()
+	local r1 = sdl.rect(10, 10, 10, 10)
+	local r2 = sdl.rect(5,  12, 10, 6)
+	Assert.True(rect_intersects(r1, r2))
+	return true
+end
+
+function testsuite.geometry.test_RectIntersectPartialTop()
+	local r1 = sdl.rect(10, 10, 10, 10)
+	local r2 = sdl.rect(12, 5, 6, 10)
+	Assert.True(rect_intersects(r1, r2))
+	return true
+end
+
+function testsuite.geometry.test_RectIntersectPartialRight()
+	local r1 = sdl.rect(10, 10, 10, 10)
+	local r2 = sdl.rect(15, 12, 10, 6)
+	Assert.True(rect_intersects(r1, r2))
+	return true
+end
+
+function testsuite.geometry.test_RectIntersectPartialBottom()
+	local r1 = sdl.rect(10, 10, 10, 10)
+	local r2 = sdl.rect(12, 15, 6, 10)
+	Assert.True(rect_intersects(r1, r2))
+	return true
+end
+
+function testsuite.geometry.test_RectContainsLeftEdge()
+	local r1 = sdl.rect(0, 0, 10, 10)
+	Assert.True(rect_contains(r1, 0, 5))
+	return true
+end
+
+function testsuite.geometry.test_RectContainsTopEdge()
+	local r1 = sdl.rect(0, 0, 10, 10)
+	Assert.True(rect_contains(r1, 5, 0))
+	return true
+end
+
+function testsuite.geometry.test_RectContainsBottomEdge()
+	local r1 = sdl.rect(0, 0, 10, 10)
+	Assert.False(rect_contains(r1, 5, 10))
+	return true
+end
+
+function testsuite.geometry.test_RectContainsRightEdge()
+	local r1 = sdl.rect(0, 0, 10, 10)
+	Assert.False(rect_contains(r1, 10, 5))
+	return true
+end
+
+function testsuite.geometry.test_RectContainsComplete()
+	local r1 = sdl.rect(0, 0, 10, 10)
+	Assert.True(rect_contains(r1, 5, 5))
+	return true
+end
+
+function testsuite.geometry.test_RectContainsOutside()
+	local r1 = sdl.rect(0, 0, 10, 10)
+	Assert.False(rect_contains(r1, 5, 15))
+	return true
+end
+
+-- ///////////////////////////////////////////////////////////////
 -- Unsorted Tests
 
 function testsuite.test_GetParentPathTerminatedSlashes()

--- a/scripts/mod_loader/ui/__scripts.lua
+++ b/scripts/mod_loader/ui/__scripts.lua
@@ -16,6 +16,7 @@ local scripts = {
 
 	"widgets/base",
 	"widgets/draggable",
+	"widgets/dragdroplist",
 	"widgets/boxlayout",
 	"widgets/flowlayout",
 	"widgets/weightlayout",

--- a/scripts/mod_loader/ui/decorations/deco_button.lua
+++ b/scripts/mod_loader/ui/decorations/deco_button.lua
@@ -18,7 +18,9 @@ function DecoButton:draw(screen, widget)
 
 	if widget.hovered then
 		basecolor = self.hlcolor
-		bordercolor = self.borderhlcolor
+		if widget.containsMouse or widget.dragMoving then
+			bordercolor = self.borderhlcolor
+		end
 	end
 	if widget.disabled then
 		basecolor = self.disabledcolor

--- a/scripts/mod_loader/ui/widgets/base.lua
+++ b/scripts/mod_loader/ui/widgets/base.lua
@@ -374,7 +374,8 @@ function Ui:updateHoveredState()
 end
 
 function Ui:updateTooltipState()
-	self.root.tooltip = self.tooltip or ""
+	self.root.tooltip_title = self.tooltip_title
+	self.root.tooltip = self.tooltip
 end
 
 -- update is called for all element after everything has been

--- a/scripts/mod_loader/ui/widgets/base.lua
+++ b/scripts/mod_loader/ui/widgets/base.lua
@@ -379,9 +379,9 @@ end
 -- update is called for all element after everything has been
 -- relayed out, and every state has been updated.
 -- elements can override this function for additional updates.
-function Ui:update()
+function Ui:updateState()
 	for _, child in ipairs(self.children) do
-		child:update()
+		child:updateState()
 	end
 end
 

--- a/scripts/mod_loader/ui/widgets/base.lua
+++ b/scripts/mod_loader/ui/widgets/base.lua
@@ -62,7 +62,7 @@ end
 function Ui:remove(child)
 	if not child then return self end
 
-	if self.root.focuschild == child then
+	if self.root and self.root.focuschild == child then
 		-- pass self as arg for UiRoot override
 		self:setfocus(self)
 	end

--- a/scripts/mod_loader/ui/widgets/base.lua
+++ b/scripts/mod_loader/ui/widgets/base.lua
@@ -269,13 +269,11 @@ function Ui:setTranslucent(translucent, cascade)
 end
 
 local function handleMouseEvent(self, mx, my, func, ...)
-	if not self.visible or self.ignoreMouse or not self.containsMouse then
-		return false
-	end
-
 	for _, child in ipairs(self.children) do
-		if child[func](child, mx, my, ...) then
-			return true
+		if child.visible and child.containsMouse and not child.ignoreMouse then
+			if child[func](child, mx, my, ...) then
+				return true
+			end
 		end
 	end
 

--- a/scripts/mod_loader/ui/widgets/base.lua
+++ b/scripts/mod_loader/ui/widgets/base.lua
@@ -390,6 +390,7 @@ end
 function Ui:updateTooltipState()
 	self.root.tooltip_title = self.tooltip_title
 	self.root.tooltip = self.tooltip
+	self.root.tooltip_static = self.draggable and self.dragged
 end
 
 -- update is called for all element after everything has been

--- a/scripts/mod_loader/ui/widgets/base.lua
+++ b/scripts/mod_loader/ui/widgets/base.lua
@@ -354,12 +354,8 @@ function Ui:updateHoveredState()
 		return false
 	end
 
-	if not self.translucent then
-		if self.root.hoveredchild ~= nil then
-			self.root.hoveredchild.hovered = false
-		end
-		self.root.hoveredchild = self
-		self.hovered = true
+	if not self.translucent and self.root then
+		self.root:setHoveredChild(self)
 	end
 
 	for _, child in ipairs(self.children) do

--- a/scripts/mod_loader/ui/widgets/base.lua
+++ b/scripts/mod_loader/ui/widgets/base.lua
@@ -371,6 +371,22 @@ function Ui:updateHoveredState()
 	return self.hovered
 end
 
+function Ui:updateAnimations()
+	if not self.visible then
+		return
+	end
+
+	if self.animations then
+		for _, anim in pairs(self.animations) do
+			anim:update(modApi:deltaTime())
+		end
+	end
+
+	for _, child in ipairs(self.children) do
+		child:updateAnimations()
+	end
+end
+
 function Ui:updateTooltipState()
 	self.root.tooltip_title = self.tooltip_title
 	self.root.tooltip = self.tooltip
@@ -483,12 +499,6 @@ function Ui:draw(screen)
 		end
 		
 		screen:clip(clipRect)
-	end
-	
-	if self.animations then
-		for _, anim in pairs(self.animations) do
-			anim:update(modApi:deltaTime())
-		end
 	end
 	
 	self.decorationx = 0

--- a/scripts/mod_loader/ui/widgets/base.lua
+++ b/scripts/mod_loader/ui/widgets/base.lua
@@ -268,197 +268,35 @@ function Ui:setTranslucent(translucent, cascade)
 	return self
 end
 
-function Ui:wheel(mx,my,y)
-	if not self.visible then return false end
-	if self.ignoreMouse then return false end
-
-	if self.dragged then
-		self:dragWheel(mx, my, y)
-		return true
+local function handleMouseEvent(self, mx, my, func, ...)
+	if not self.visible or self.ignoreMouse or not self.containsMouse then
+		return false
 	end
 
-	for i=1,#self.children do
-		local child = self.children[i]
-		
-		if
-			child.visible      and
-			rect_contains(
-				child.screenx,
-				child.screeny,
-				child.w,
-				child.h,
-				mx, my
-			)
-		then
-			if child:wheel(mx,my,y) then
-				return true
-			end
+	for _, child in ipairs(self.children) do
+		if child[func](child, mx, my, ...) then
+			return true
 		end
 	end
 
 	if self.translucent then return false end
 	return true
+end
+
+function Ui:wheel(mx,my,y)
+	return handleMouseEvent(self, mx, my, "wheel", y)
 end
 
 function Ui:mousedown(mx, my, button)
-	if not self.visible then return false end
-	if self.ignoreMouse then return false end
-
-	for i=1,#self.children do
-		local child = self.children[i]
-
-		if
-			child.visible      and
-			rect_contains(
-				child.screenx,
-				child.screeny,
-				child.w,
-				child.h,
-				mx, my
-			)
-		then
-			if child:mousedown(mx, my, button) then
-				return true
-			end
-		end
-	end
-
-	if self.root.pressedchild ~= nil then
-		self.root.pressedchild.pressed = false
-	end
-
-	self.root.pressedchild = self
-	-- pass self as arg for UiRoot override
-	self:setfocus(self)
-	self.pressed = true
-
-	if self.draggable and not self.disabled and button == 1 then
-		self.dragged = true
-		self:startDrag(mx, my, button)
-		return true
-	end
-
-	if self.translucent then return false end
-	return true
+	return handleMouseEvent(self, mx, my, "mousedown", button)
 end
 
 function Ui:mouseup(mx, my, button)
-	if not self.visible then return false end
-	if self.ignoreMouse then return false end
-
-	local contains = rect_contains(
-		self.screenx,
-		self.screeny,
-		self.w,
-		self.h,
-		mx, my
-	)
-
-	if not contains then
-		self.root.hoveredchild = nil
-		self.hovered = false
-		-- Cleanup the tooltip to prevent flickering when mouse is
-		-- first moved after the release
-		self.root.tooltip_static = false
-		self.root.tooltip_title = ""
-		self.root.tooltip = ""
-		self.root.tooltipUi:updateText()
-	end
-
-	if self.dragged and button == 1 then
-		self.dragged = false
-		self:stopDrag(mx, my, button)
-		return true
-	end
-
-	if
-		self.root.pressedchild == self and
-		self.pressed                   and
-		not self.disabled              and
-		contains
-	then
-		self.pressed = false
-		if self:clicked(button) then return true end
-	end
-
-	for i=1,#self.children do
-		local child = self.children[i]
-		
-		if
-			child ~= self.root.pressedchild and
-			child.visible                   and
-			rect_contains(
-				child.screenx,
-				child.screeny,
-				child.w,
-				child.h,
-				mx, my
-			)
-		then
-			if child:mouseup(mx, my, button) then
-				return true
-			end
-		end
-	end
-
-	if self.translucent then return false end
-	return true
+	return handleMouseEvent(self, mx, my, "mouseup", button)
 end
 
 function Ui:mousemove(mx, my)
-	if not self.visible then return false end
-	if self.ignoreMouse then return false end
-
-	if self.root.hoveredchild ~= nil then
-		self.root.hoveredchild.hovered = false
-	end
-
-	self.root.hoveredchild = self
-	self.hovered = true
-
-	table.insert(self.root.highlightedChildren, self)
-	self.highlighted = true
-
-	if self.dragged then
-		self:dragMove(mx, my)
-		return true
-	end
-
-	if self.tooltip then
-		self.root.tooltip_static = self.tooltip_static
-		self.root.tooltip_title = self.tooltip_title
-		self.root.tooltip = self.tooltip
-	end
-
-	for i=1,#self.children do
-		local child = self.children[i]
-		if
-			child ~= self.root.pressedchild and
-			child.visible                   and
-			rect_contains(
-				child.screenx,
-				child.screeny,
-				child.w,
-				child.h,
-				mx, my
-			)
-		then
-			if not child.containsMouse then
-				child.containsMouse = true
-				child:mouseEntered()
-			end
-
-			if child:mousemove(mx, my) then
-				return true
-			end
-		elseif child.containsMouse then
-			child.containsMouse = false
-			child:mouseExited()
-		end
-	end
-	
-	if self.translucent then return false end
-	return true
+	return handleMouseEvent(self, mx, my, "mousemove")
 end
 
 function Ui:keydown(keycode)
@@ -479,6 +317,73 @@ function Ui:keyup(keycode)
 	end
 
 	return false
+end
+
+-- calling this function will update containsMouse
+-- for this element and its children, and call
+-- mouseEntered and mouseExited when applicable.
+function Ui:updateContainsMouse(mx, my)
+	local curr_containsMouse
+	if not self.visible or self.ignoreMouse then
+		curr_containsMouse = false
+	else
+		curr_containsMouse = rect_contains(
+			self.screenx,
+			self.screeny,
+			self.w,
+			self.h,
+			mx, my
+		)
+	end
+
+	if curr_containsMouse ~= self.containsMouse then
+		if curr_containsMouse then
+			self:mouseEntered()
+		else
+			self:mouseExited()
+		end
+
+		self.containsMouse = curr_containsMouse
+	end
+
+	for _, child in ipairs(self.children) do
+		child:updateContainsMouse(mx, my)
+	end
+end
+
+function Ui:updateHoveredState()
+	if not self.visible or self.ignoreMouse or not self.containsMouse then
+		return false
+	end
+
+	if not self.translucent then
+		if self.root.hoveredchild ~= nil then
+			self.root.hoveredchild.hovered = false
+		end
+		self.root.hoveredchild = self
+		self.hovered = true
+	end
+
+	for _, child in ipairs(self.children) do
+		if child:updateHoveredState() then
+			return true
+		end
+	end
+
+	return self.hovered
+end
+
+function Ui:updateTooltipState()
+	self.root.tooltip = self.tooltip or ""
+end
+
+-- update is called for all element after everything has been
+-- relayed out, and every state has been updated.
+-- elements can override this function for additional updates.
+function Ui:update()
+	for _, child in ipairs(self.children) do
+		child:update()
+	end
 end
 
 function Ui:relayout()
@@ -646,9 +551,11 @@ function Ui:stopDrag(mx, my, button)
 end
 
 function Ui:dragMove(mx, my)
+	return false
 end
 
 function Ui:dragWheel(mx, my, y)
+	return false
 end
 
 function Ui:startDrag(mx, my, button)

--- a/scripts/mod_loader/ui/widgets/dragdroplist.lua
+++ b/scripts/mod_loader/ui/widgets/dragdroplist.lua
@@ -47,7 +47,7 @@ function UiDragDropList:stopDrag(mx, my, button)
 end
 
 function Ui:registerDragDropList(placeholder)
-	Assert.NotEquals('nil', type(placeholder), "Argument #1")
+	Assert.True(Class.instanceOf(placeholder, Ui), "[Argument #1]:instanceOf(Ui)")
 	self:registerDragMove()
 	self.dragPlaceholder = placeholder
 	self.startDrag = UiDragDropList.startDrag

--- a/scripts/mod_loader/ui/widgets/dragdroplist.lua
+++ b/scripts/mod_loader/ui/widgets/dragdroplist.lua
@@ -1,0 +1,55 @@
+UiDragDropList = Class.inherit(UiDraggable)
+
+function UiDragDropList:new()
+	UiDraggable.new(self)
+end
+
+function UiDragDropList:startDrag(mx, my, button)
+	if button ~= 1 then
+		return
+	end
+
+	UiDraggable.startDrag(self, mx, my, button)
+
+	if self.dragPlaceholder ~= nil then
+		local root = sdlext.getUiRoot()
+		local owner = self.parent
+		local index = list_indexof(owner.children, self)
+		self:detach()
+		self.owner = owner
+		self.translucent = true
+
+		owner:add(self.dragPlaceholder, index)
+		self.dragPlaceholder:show()
+
+		self:addTo(root.draggableUi)
+		self.x = self.screenx
+		self.y = self.screeny
+	end
+end
+
+function UiDragDropList:stopDrag(mx, my, button)
+	if button ~= 1 then
+		return
+	end
+
+	if self.dragMoving and self.dragPlaceholder ~= nil then
+		local index = list_indexof(self.owner.children, self.dragPlaceholder)
+		self.dragPlaceholder:detach()
+		self.dragPlaceholder:hide()
+
+		self:detach()
+		self:addTo(self.owner, index)
+		self.translucent = self.dragPlaceholder.translucent
+	end
+
+	UiDraggable.stopDrag(self, mx, my, button)
+end
+
+function Ui:registerDragDropList(placeholder)
+	Assert.NotEquals('nil', type(placeholder), "Argument #1")
+	self:registerDragMove()
+	self.dragPlaceholder = placeholder
+	self.startDrag = UiDragDropList.startDrag
+	self.stopDrag = UiDragDropList.stopDrag
+end

--- a/scripts/mod_loader/ui/widgets/dragdroplist.lua
+++ b/scripts/mod_loader/ui/widgets/dragdroplist.lua
@@ -25,6 +25,8 @@ function UiDragDropList:startDrag(mx, my, button)
 		self:addTo(root.draggableUi)
 		self.x = self.screenx
 		self.y = self.screeny
+
+		root:setfocus(self)
 	end
 end
 
@@ -46,10 +48,25 @@ function UiDragDropList:stopDrag(mx, my, button)
 	UiDraggable.stopDrag(self, mx, my, button)
 end
 
+function UiDragDropList:keydown(keycode)
+	if keycode == SDLKeycodes.ESCAPE then
+		self:stopDrag(sdl.mouse.x(), sdl.mouse.y(), 1)
+		self.root:setPressedChild(nil)
+		self.root:setDraggedChild(nil)
+	end
+	return true
+end
+
+function UiDragDropList:keyup(keycode)
+	return true
+end
+
 function Ui:registerDragDropList(placeholder)
 	Assert.True(Class.instanceOf(placeholder, Ui), "[Argument #1]:instanceOf(Ui)")
 	self:registerDragMove()
 	self.dragPlaceholder = placeholder
 	self.startDrag = UiDragDropList.startDrag
 	self.stopDrag = UiDragDropList.stopDrag
+	self.keydown = UiDragDropList.keydown
+	self.keyup = UiDragDropList.keyup
 end

--- a/scripts/mod_loader/ui/widgets/draggable.lua
+++ b/scripts/mod_loader/ui/widgets/draggable.lua
@@ -198,12 +198,14 @@ function UiDraggable:dragMove(mx, my)
 			self.h = math.max(self.dragH + my - self.dragY, minsize)
 		end
 	elseif self.dragMovable and self.dragMoving then
-		self.x = self.x + mx - self.dragX
-		self.y = self.y + my - self.dragY
+		local diffx = mx - self.dragX
+		local diffy = my - self.dragY
+		self.x = self.x + diffx
+		self.y = self.y + diffy
+		self.screenx = self.screenx + diffx
+		self.screeny = self.screeny + diffy
 		self.dragX = mx
 		self.dragY = my
-		self.screenx = self.x
-		self.screeny = self.y
 
 		self:processDropTargets(mx, my)
 	else

--- a/scripts/mod_loader/ui/widgets/draggable.lua
+++ b/scripts/mod_loader/ui/widgets/draggable.lua
@@ -91,10 +91,6 @@ function UiDraggable:startDrag(mx, my, button)
 		self.x = self.screenx
 		self.y = self.screeny
 	end
-
-	if self.parent then
-		self.parent:relayout()
-	end
 end
 
 function UiDraggable:stopDrag(mx, my, button)

--- a/scripts/mod_loader/ui/widgets/draggable.lua
+++ b/scripts/mod_loader/ui/widgets/draggable.lua
@@ -75,22 +75,6 @@ function UiDraggable:startDrag(mx, my, button)
 		self.dragResizing = UiDraggable.isEdge(self, mx, my, self.__resizeHandle)
 		self.__resizeDir = getResizeDirection(self, mx, my, self.__resizeHandle)
 	end
-
-	if self.dragPlaceholder ~= nil then
-		local root = sdlext.getUiRoot()
-		local owner = self.parent
-		local index = list_indexof(owner.children, self)
-		self:detach()
-		self.owner = owner
-		self.translucent = true
-
-		owner:add(self.dragPlaceholder, index)
-		self.dragPlaceholder:show()
-
-		self:addTo(root.draggableUi)
-		self.x = self.screenx
-		self.y = self.screeny
-	end
 end
 
 function UiDraggable:stopDrag(mx, my, button)
@@ -98,16 +82,6 @@ function UiDraggable:stopDrag(mx, my, button)
 
 	if button ~= 1 then
 		return
-	end
-
-	if self.dragMoving and self.dragPlaceholder ~= nil then
-		local index = list_indexof(self.owner.children, self.dragPlaceholder)
-		self.dragPlaceholder:detach()
-		self.dragPlaceholder:hide()
-
-		self:detach()
-		self:addTo(self.owner, index)
-		self.translucent = self.dragPlaceholder.translucent
 	end
 
 	self.dragMoving   = false
@@ -275,10 +249,6 @@ function Ui:registerDragMove()
 	registerDragFunctions(self)
 	self.draggable   = true
 	self.dragMovable = true
-end
-
-function Ui:registerDragPlaceholder(placeholder)
-	self.dragPlaceholder = placeholder
 end
 
 function Ui:registerDragResize(resizeHandleSize, minSize)

--- a/scripts/mod_loader/ui/widgets/draggable.lua
+++ b/scripts/mod_loader/ui/widgets/draggable.lua
@@ -129,7 +129,7 @@ function UiDraggable:processDropTargets(mx, my)
 	local target = self.hoverTarget
 
 	if target then
-		if not rect_contains(target.rect, mx, my) then
+		if not target.containsMouse then
 			self.hoverTarget = nil
 
 			if target.onDraggableExited then
@@ -141,7 +141,7 @@ function UiDraggable:processDropTargets(mx, my)
 
 	for i = first, #dropTargets do
 		local target = dropTargets[i]
-		if self ~= target and rect_contains(target.rect, mx, my) then
+		if self ~= target and target.containsMouse then
 			self.hoverTarget = target
 
 			if target.onDraggableEntered then

--- a/scripts/mod_loader/ui/widgets/draggable.lua
+++ b/scripts/mod_loader/ui/widgets/draggable.lua
@@ -11,6 +11,10 @@ function UiDraggable:new()
 end
 
 function UiDraggable:isEdge(mx, my)
+	if not self.containsMouse then
+		return false
+	end
+
 	local resizeHandle = self.__resizeHandle
 	return mx < self.screenx + resizeHandle          or
 	       my < self.screeny + resizeHandle          or

--- a/scripts/mod_loader/ui/widgets/dropdown.lua
+++ b/scripts/mod_loader/ui/widgets/dropdown.lua
@@ -137,8 +137,6 @@ function UiDropDown:createDropDown()
 		self.dropdown.visible = true
 		self.dropdown.x = self.rect.x + self.w - ddw
 		self.dropdown.y = self.rect.y + self.h + 2
-		
-		self.dropdown.parent:relayout()
 	end
 end
 

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -234,6 +234,10 @@ function UiRoot:event(eventloop)
 			end
 		end
 
+		if not consumeEvent then
+			consumeEvent = self:mousedown(mx, my, button)
+		end
+
 		self:cleanupDropdown()
 
 		return consumeEvent

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -97,6 +97,13 @@ function UiRoot:cleanupDropdown()
 	end
 end
 
+function UiRoot:updatePressedState(mx, my)
+	-- release the pressed element if it has become orphaned from root
+	if self.pressedchild and self.pressedchild.root ~= self then
+		self:releasePressedchild(mx, my, 1)
+	end
+end
+
 function UiRoot:updateHoveredState()
 	if self.hoveredchild ~= nil then
 		self.hoveredchild.hovered = false
@@ -136,6 +143,7 @@ end
 function UiRoot:updateStates()
 	local mx, my = sdl.mouse.x(), sdl.mouse.y()
 	self:updateContainsMouse(mx, my)
+	self:updatePressedState(mx, my)
 	self:updateHoveredState()
 	self:updateDraggedState()
 	self:updateAnimations()

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -248,8 +248,6 @@ function UiRoot:event(eventloop)
 
 		if button == 1 and self.pressedchild ~= nil then
 			return self:releasePressedchild(mx, my, button)
-		elseif button == 3 and self.hoveredchild ~= nil then
-			return self.hoveredchild:mouseup(mx, my, button)
 		end
 
 		return self:mouseup(mx, my, button)

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -154,8 +154,14 @@ function UiRoot:releasePressedchild(mx, my, button)
 		self.pressedchild.pressed = false
 		self.pressedchild = nil
 
-		if button == 1 and pressedchild.containsMouse then
-			return pressedchild:clicked(button)
+		if button == 1 then
+			local consumeEvent = pressedchild:mouseup(mx, my, button)
+
+			if pressedchild.containsMouse and pressedchild:clicked(button) then
+				consumeEvent = true
+			end
+
+			return consumeEvent
 		end
 	end
 
@@ -221,8 +227,14 @@ function UiRoot:event(eventloop)
 	if type == sdl.events.mousemotion then
 		local pressedchild = self.pressedchild
 
-		if pressedchild ~= nil and pressedchild.dragged then
-			if pressedchild:dragMove(mx, my) then
+		if pressedchild ~= nil then
+			local consumeEvent = pressedchild:mousemove(mx, my)
+
+			if pressedchild.dragged and pressedchild:dragMove(mx, my) then
+				consumeEvent = true
+			end
+
+			if consumeEvent then
 				return true
 			end
 		end

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -138,6 +138,7 @@ function UiRoot:updateStates()
 	self:updateContainsMouse(mx, my)
 	self:updateHoveredState()
 	self:updateDraggedState()
+	self:updateAnimations()
 	self:updateTooltipState()
 	self:updateState()
 end

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -105,13 +105,13 @@ function UiRoot:updatePressedState(mx, my)
 end
 
 function UiRoot:updateHoveredState()
-	if self.hoveredchild ~= nil then
+	if self.hoveredchild then
 		self.hoveredchild.hovered = false
 	end
 	self.hoveredchild = nil
 
 	-- if there is a pressed element, keep it hovered.
-	if self.pressedchild ~= nil then
+	if self.pressedchild then
 		self.hoveredchild = self.pressedchild
 		self.hoveredchild.hovered = true
 		return false
@@ -126,17 +126,14 @@ function UiRoot:updateTooltipState()
 	self.tooltip_title = ""
 	self.tooltip = ""
 
-	if self.hoveredchild ~= nil and self.hoveredchild.hovered then
+	if self.hoveredchild then
 		self.hoveredchild:updateTooltipState()
 	end
 end
 
-function UiRoot:updateDraggedState()
-	if self.pressedchild ~= nil then
-		if self.pressedchild.dragged then
-			local mx, my = sdl.mouse.x(), sdl.mouse.y()
-			self.pressedchild:dragMove(mx, my)
-		end
+function UiRoot:updateDraggedState(mx, my)
+	if self.draggedchild then
+		self.draggedchild:dragMove(mx, my)
 	end
 end
 
@@ -145,7 +142,7 @@ function UiRoot:updateStates()
 	self:updateContainsMouse(mx, my)
 	self:updatePressedState(mx, my)
 	self:updateHoveredState()
-	self:updateDraggedState()
+	self:updateDraggedState(mx, my)
 	self:updateAnimations()
 	self:updateTooltipState()
 	self:updateState()
@@ -171,7 +168,7 @@ function UiRoot:releasePressedchild(mx, my, button)
 	local draggedchild = self.draggedchild
 	local pressedchild = self.pressedchild
 
-	if draggedchild ~= nil then
+	if draggedchild then
 		self.draggedchild.dragged = false
 		self.draggedchild = nil
 
@@ -179,7 +176,7 @@ function UiRoot:releasePressedchild(mx, my, button)
 		draggedchild:stopDrag(mx, my, 1)
 	end
 
-	if pressedchild ~= nil then
+	if pressedchild then
 		self.pressedchild.pressed = false
 		self.pressedchild = nil
 
@@ -208,7 +205,7 @@ function UiRoot:event(eventloop)
 		local pressedchild = self.pressedchild
 		local wheel = eventloop:wheel()
 
-		if pressedchild ~= nil then
+		if pressedchild then
 			local consumeEvent = pressedchild:wheel(mx, my, wheel)
 
 			if pressedchild.dragged and pressedchild:dragWheel(mx, my, wheel) then
@@ -255,7 +252,7 @@ function UiRoot:event(eventloop)
 	if type == sdl.events.mousebuttonup then
 		local button = eventloop:mousebutton()
 
-		if button == 1 and self.pressedchild ~= nil then
+		if button == 1 and self.pressedchild then
 			return self:releasePressedchild(mx, my, button)
 		end
 
@@ -265,7 +262,7 @@ function UiRoot:event(eventloop)
 	if type == sdl.events.mousemotion then
 		local pressedchild = self.pressedchild
 
-		if pressedchild ~= nil then
+		if pressedchild then
 			local consumeEvent = pressedchild:mousemove(mx, my)
 
 			if pressedchild.dragged and pressedchild:dragMove(mx, my) then

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -1,8 +1,15 @@
 UiRoot = Class.inherit(Ui)
 
 local function PriorityUi()
-	return Ui():width(1):height(1):setTranslucent()
+	local ui = Ui()
+		:width(1):height(1)
+		:setTranslucent()
+	ui.nofitx = true
+	ui.nofity = true
+
+	return ui
 end
+
 function UiRoot:new()
 	Ui.new(self)
 	

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -177,14 +177,19 @@ function UiRoot:event(eventloop)
 	
 	if type == sdl.events.mousewheel then
 		local pressedchild = self.pressedchild
+		local wheel = eventloop:wheel()
 
-		if pressedchild ~= nil and pressedchild.dragged then
-			if pressedchild:dragWheel(mx, my, eventloop:wheel()) then
-				return true
+		if pressedchild ~= nil then
+			local consumeEvent = pressedchild:wheel(mx, my, wheel)
+
+			if pressedchild.dragged and pressedchild:dragWheel(mx, my, wheel) then
+				consumeEvent = true
 			end
+
+			return consumeEvent
 		end
 
-		return self:wheel(mx, my, eventloop:wheel())
+		return self:wheel(mx, my, wheel)
 	end
 
 	if type == sdl.events.mousebuttondown then

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -141,15 +141,10 @@ function UiRoot:updatePressedState(mx, my)
 end
 
 function UiRoot:updateHoveredState()
-	if self.hoveredchild then
-		self.hoveredchild.hovered = false
-	end
-	self.hoveredchild = nil
-
 	-- if there is a pressed element, keep it hovered.
-	if self.pressedchild then
-		self.hoveredchild = self.pressedchild
-		self.hoveredchild.hovered = true
+	self:setHoveredChild(self.pressedchild)
+
+	if self.hoveredchild then
 		return false
 	end
 
@@ -188,12 +183,10 @@ function UiRoot:pressHoveredchild(mx, my, button)
 	local pressedchild = self.hoveredchild
 	if pressedchild == nil then return end
 
-	self.pressedchild = pressedchild
-	pressedchild.pressed = true
+	self:setPressedChild(pressedchild)
 
 	if pressedchild.draggable then
-		self.draggedchild = pressedchild
-		pressedchild.dragged = true
+		self:setDraggedChild(pressedchild)
 		pressedchild:startDrag(mx, my, button)
 	end
 
@@ -205,16 +198,14 @@ function UiRoot:releasePressedchild(mx, my, button)
 	local pressedchild = self.pressedchild
 
 	if draggedchild then
-		self.draggedchild.dragged = false
-		self.draggedchild = nil
+		self:setDraggedChild(nil)
 
 		-- Hack: always call stopDrag with argument button = 1
 		draggedchild:stopDrag(mx, my, 1)
 	end
 
 	if pressedchild then
-		self.pressedchild.pressed = false
-		self.pressedchild = nil
+		self:setPressedChild(nil)
 
 		if button == 1 then
 			local consumeEvent = pressedchild:mouseup(mx, my, button)
@@ -244,7 +235,7 @@ function UiRoot:event(eventloop)
 		if pressedchild then
 			local consumeEvent = pressedchild:wheel(mx, my, wheel)
 
-			if pressedchild.dragged and pressedchild:dragWheel(mx, my, wheel) then
+			if self.draggedchild and self.draggedchild:dragWheel(mx, my, wheel) then
 				consumeEvent = true
 			end
 
@@ -301,7 +292,7 @@ function UiRoot:event(eventloop)
 		if pressedchild then
 			local consumeEvent = pressedchild:mousemove(mx, my)
 
-			if pressedchild.dragged and pressedchild:dragMove(mx, my) then
+			if self.draggedchild and self.draggedchild:dragMove(mx, my) then
 				consumeEvent = true
 			end
 

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -193,7 +193,9 @@ function UiRoot:event(eventloop)
 				consumeEvent = true
 			end
 
-			return consumeEvent
+			if consumeEvent then
+				return true
+			end
 		end
 
 		return self:wheel(mx, my, wheel)

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -139,7 +139,7 @@ function UiRoot:updateStates()
 	self:updateHoveredState()
 	self:updateDraggedState()
 	self:updateTooltipState()
-	self:update()
+	self:updateState()
 end
 
 function UiRoot:pressHoveredchild(mx, my, button)

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -1,15 +1,19 @@
 UiRoot = Class.inherit(Ui)
 
+local function PriorityUi()
+	return Ui():width(1):height(1):setTranslucent()
+end
 function UiRoot:new()
 	Ui.new(self)
 	
-	self.highlightedChildren = {}
 	self.hoveredchild = nil
 	self.pressedchild = nil
 	self.focuschild = self
 	self.translucent = true
-	self.priorityUi = Ui():addTo(self)
+	self.priorityUi = PriorityUi():addTo(self)
 	self.tooltipUi = UiTooltip():addTo(self.priorityUi)
+	self.dropdownUi = PriorityUi():addTo(self.priorityUi)
+	self.draggableUi = PriorityUi():addTo(self.priorityUi)
 end
 
 function UiRoot:draw(screen)
@@ -19,16 +23,15 @@ function UiRoot:draw(screen)
 
 	self.priorityUi.visible = true
 	self.priorityUi:bringToTop()
-	self.priorityUi:relayout()
+	self.dropdownUi:relayout()
+	self.draggableUi:relayout()
+
+	self:updateStates()
+
+	-- update tooltip after everything else has been updated
+	self.tooltipUi:relayout()
 
 	Ui.draw(self, screen)
-	
-	if self.currentDropDown then
-		self:add(self.currentDropDown)
-		self:relayout()
-		self.currentDropDown:draw(screen)
-		table.remove(self.children)
-	end
 end
 
 function UiRoot:setfocus(newfocus)
@@ -57,20 +60,103 @@ function UiRoot:setfocus(newfocus)
 	return true
 end
 
-function UiRoot:dropdownEvent(x,y)
-	if
-		self.currentDropDown and
-		rect_contains(
-			self.currentDropDown.screenx,
-			self.currentDropDown.screeny,
-			self.currentDropDown.w,
-			self.currentDropDown.h,
-			x, y
-		)
-	then
-		self:add(self.currentDropDown)
-		self:relayout()
-		return true
+function UiRoot:cleanupDropdown()
+	for i = #self.dropdownUi.children, 1, -1 do
+		local dropdown = self.dropdownUi.children[i]
+
+		local parent = dropdown.owner
+		while parent.parent do
+			-- fetch root of dropDown
+			parent = parent.parent
+		end
+
+		-- if owner is not attached to root, remove dropDown
+		if parent ~= self then
+			table.remove(self.dropdownUi.children, i)
+		end
+	end
+end
+
+function UiRoot:updateHoveredState()
+	if self.hoveredchild ~= nil then
+		self.hoveredchild.hovered = false
+	end
+	self.hoveredchild = nil
+
+	-- if there is a pressed element, keep it hovered.
+	if self.pressedchild ~= nil then
+		self.hoveredchild = self.pressedchild
+		self.hoveredchild.hovered = true
+		return false
+	end
+
+	Ui.updateHoveredState(self)
+	return false
+end
+
+function UiRoot:updateTooltipState()
+	self.tooltip_static = false
+	self.tooltip_title = false
+	self.tooltip = ""
+
+	if self.hoveredchild ~= nil and self.hoveredchild.hovered then
+		self.hoveredchild:updateTooltipState()
+	end
+end
+
+function UiRoot:updateDraggedState()
+	if self.pressedchild ~= nil then
+		if self.pressedchild.dragged then
+			local mx, my = sdl.mouse.x(), sdl.mouse.y()
+			self.pressedchild:dragMove(mx, my)
+		end
+	end
+end
+
+function UiRoot:updateStates()
+	local mx, my = sdl.mouse.x(), sdl.mouse.y()
+	self:updateContainsMouse(mx, my)
+	self:updateHoveredState()
+	self:updateDraggedState()
+	self:updateTooltipState()
+	self:update()
+end
+
+function UiRoot:pressHoveredchild(mx, my, button)
+	local pressedchild = self.hoveredchild
+	if pressedchild == nil then return end
+
+	self.pressedchild = pressedchild
+	pressedchild.pressed = true
+
+	if pressedchild.draggable then
+		self.draggedchild = pressedchild
+		pressedchild.dragged = true
+		pressedchild:startDrag(mx, my, button)
+	end
+
+	return pressedchild:mousedown(mx, my, button)
+end
+
+function UiRoot:releasePressedchild(mx, my, button)
+	local draggedchild = self.draggedchild
+	local pressedchild = self.pressedchild
+
+	if draggedchild ~= nil then
+		self.draggedchild.dragged = false
+		self.draggedchild = nil
+
+		-- Hack: always call stopDrag with argument button = 1
+		draggedchild:stopDrag(mx, my, 1)
+	end
+
+	if pressedchild ~= nil then
+		self.pressedchild.pressed = false
+		self.pressedchild = nil
+
+		if button == 1 and pressedchild.containsMouse then
+			return pressedchild:clicked(button)
+		end
 	end
 
 	return false
@@ -84,11 +170,11 @@ function UiRoot:event(eventloop)
 	local my = sdl.mouse.y()
 	
 	if type == sdl.events.mousewheel then
-		if self:dropdownEvent(mx, my) then
-			local done = self.currentDropDown:wheel(mx, my, eventloop:wheel())
-			table.remove(self.children)
-			if done then
-				return done
+		local pressedchild = self.pressedchild
+
+		if pressedchild ~= nil and pressedchild.dragged then
+			if pressedchild:dragWheel(mx, my, eventloop:wheel()) then
+				return true
 			end
 		end
 
@@ -97,66 +183,50 @@ function UiRoot:event(eventloop)
 
 	if type == sdl.events.mousebuttondown then
 		local button = eventloop:mousebutton()
-		self:setfocus(nil)
-		local done = self:mousedown(mx, my, button)
-		if self:dropdownEvent(mx, my) then
-			done = self.currentDropDown:mousedown(mx, my, button) or done
-			table.remove(self.children)
+		local consumeEvent = false
+
+		self:releasePressedchild(mx, my, button)
+		self:setfocus(self.hoveredchild)
+
+		if button == 1 then
+			consumeEvent = self:pressHoveredchild(mx, my, button)
 		end
-		return done
+
+		-- inform open dropDownUi's of mouse down event,
+		-- even if the mouse click was outside of its area,
+		-- in order to allow them to close
+		for _, dropdown in ipairs(self.dropdownUi.children) do
+			if not dropdown.containsMouse then
+				dropdown:mousedown(mx, my, button)
+			end
+		end
+
+		self:cleanupDropdown()
+
+		return consumeEvent
 	end
 	
 	if type == sdl.events.mousebuttonup then
 		local button = eventloop:mousebutton()
-		local child = self.pressedchild
 
-		local dEvent = self:dropdownEvent(mx, my)
-		if
-			self.currentDropDown and self.currentDropDownOwner ~= child and
-			not dEvent
-		then
-			-- destroy the dropdown if we click somewhere away from it
-			self.currentDropDownOwner.hovered = false
-			self.currentDropDownOwner:destroyDropDown()
-		end
-		if dEvent then table.remove(self.children) end
-		
-		-- Notify pressed children of the event, even if the mouse is released
-		-- outside of them.
-		if self.pressedchild and self.pressedchild:mouseup(mx, my, button) then
-			self.pressedchild.pressed = false
-			self.pressedchild = nil
-			return true
+		if button == 1 and self.pressedchild ~= nil then
+			return self:releasePressedchild(mx, my, button)
+		elseif button == 3 and self.hoveredchild ~= nil then
+			return self.hoveredchild:mouseup(mx, my, button)
 		end
 
-		local res = self:mouseup(mx, my, button)
-		self.pressedchild = nil
-		return res
+		return self:mouseup(mx, my, button)
 	end
 	
 	if type == sdl.events.mousemotion then
-		for i = #self.highlightedChildren, 1, -1 do
-			self.highlightedChildren[i].highlighted = false
-			table.remove(self.highlightedChildren, i)
-		end
-		if self.hoveredchild ~= nil then
-			self.hoveredchild.hovered = false
-		end
-		self.hoveredchild = nil
-		self.tooltip_static = false
-		self.tooltip_title = false
-		self.tooltip = ""
+		local pressedchild = self.pressedchild
 
-		if self.pressedchild ~= nil then
-			return self.pressedchild:mousemove(mx, my)
+		if pressedchild ~= nil and pressedchild.dragged then
+			if pressedchild:dragMove(mx, my) then
+				return true
+			end
 		end
-		
-		if self:dropdownEvent(mx,my) then
-			local handled = self.currentDropDown:mousemove(mx, my)
-			table.remove(self.children)
-			return handled
-		end
-		
+
 		return self:mousemove(mx, my)
 	end
 

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -18,9 +18,9 @@ function UiRoot:new()
 	self.focuschild = self
 	self.translucent = true
 	self.priorityUi = PriorityUi():addTo(self)
-	self.tooltipUi = UiTooltip():addTo(self.priorityUi)
 	self.dropdownUi = PriorityUi():addTo(self.priorityUi)
 	self.draggableUi = PriorityUi():addTo(self.priorityUi)
+	self.tooltipUi = UiTooltip():addTo(self.priorityUi)
 end
 
 function UiRoot:draw(screen)
@@ -30,15 +30,28 @@ function UiRoot:draw(screen)
 
 	self.priorityUi.visible = true
 	self.priorityUi:bringToTop()
-	self.dropdownUi:relayout()
-	self.draggableUi:relayout()
+	self:relayoutDragDropPriorityUi()
 
 	self:updateStates()
 
 	-- update tooltip after everything else has been updated
-	self.tooltipUi:relayout()
+	self:relayoutTooltipUi()
 
 	Ui.draw(self, screen)
+end
+
+function UiRoot:relayoutDragDropPriorityUi()
+	self.tooltipUi.visible = false
+	self.priorityUi:relayout()
+	self.tooltipUi.visible = true
+end
+
+function UiRoot:relayoutTooltipUi()
+	self.dropdownUi.visible = false
+	self.draggableUi.visible = false
+	self.priorityUi:relayout()
+	self.dropdownUi.visible = true
+	self.draggableUi.visible = true
 end
 
 function UiRoot:setfocus(newfocus)
@@ -103,7 +116,7 @@ end
 
 function UiRoot:updateTooltipState()
 	self.tooltip_static = false
-	self.tooltip_title = false
+	self.tooltip_title = ""
 	self.tooltip = ""
 
 	if self.hoveredchild ~= nil and self.hoveredchild.hovered then

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -97,6 +97,42 @@ function UiRoot:cleanupDropdown()
 	end
 end
 
+function UiRoot:setHoveredChild(child)
+	if self.hoveredchild then
+		self.hoveredchild.hovered = false
+	end
+
+	self.hoveredchild = child
+
+	if child then
+		child.hovered = true
+	end
+end
+
+function UiRoot:setPressedChild(child)
+	if self.pressedchild then
+		self.pressedchild.pressed = false
+	end
+
+	self.pressedchild = child
+
+	if child then
+		child.pressed = true
+	end
+end
+
+function UiRoot:setDraggedChild(child)
+	if self.draggedchild then
+		self.draggedchild.dragged = false
+	end
+
+	self.draggedchild = child
+
+	if child then
+		child.dragged = true
+	end
+end
+
 function UiRoot:updatePressedState(mx, my)
 	-- release the pressed element if it has become orphaned from root
 	if self.pressedchild and self.pressedchild.root ~= self then

--- a/scripts/mod_loader/ui/widgets/scrollarea.lua
+++ b/scripts/mod_loader/ui/widgets/scrollarea.lua
@@ -50,14 +50,15 @@ function UiScrollArea:draw(screen)
 end
 
 function UiScrollArea:relayout()
-	Ui.relayout(self)
-	
-	local doUpdate = false
-	
 	if self.dy ~= self.dyTarget then
-		self.dy = math.floor(self.dy * (1 - self.scrollChangefactor) + self.dyTarget * self.scrollChangefactor)
-		doUpdate = true
+		if math.abs(self.dy - self.dyTarget) > 1 then
+			self.dy = self.dy * (1 - self.scrollChangefactor) + self.dyTarget * self.scrollChangefactor
+		else
+			self.dy = self.dyTarget
+		end
 	end
+
+	Ui.relayout(self)
 	
 	self.scrollrect.x = self.screenx + self.w - self.scrollwidth
 	self.scrollrect.y = self.screeny
@@ -85,10 +86,6 @@ function UiScrollArea:relayout()
 	self.clipRect.y = self.screeny
 	self.clipRect.w = self.w
 	self.clipRect.h = self.h
-	
-	if doUpdate then
-		Ui.mousemove(self, sdl.mouse.x(), sdl.mouse.y())
-	end
 end
 
 function UiScrollArea:mousedown(x, y, button)
@@ -132,8 +129,6 @@ function UiScrollArea:mousemove(x, y)
 	self.scrollHovered = x >= self.scrollrect.x
 
 	if self.scrollPressed then
-		self:relayout()
-
 		local ratio = (y - self.screeny - self.buttonheight/2) / (self.h-self.buttonheight)
 		if ratio < 0 then ratio = 0 end
 		if ratio > 1 then ratio = 1 end
@@ -166,7 +161,7 @@ function UiScrollAreaH:new()
 	self.dxTarget = 0
 	self.scrollSpeed = 100
 	self.scrollOvershoot = 0
-	self.scrollChangefactor = 0.35 -- <0.0, 1.0]
+	self.scrollChangefactor = 0.4 -- <0.0, 1.0]
 
 	self.scrollPressed = false
 	self.scrollHovered = false
@@ -201,14 +196,15 @@ function UiScrollAreaH:draw(screen)
 end
 
 function UiScrollAreaH:relayout()
-	Ui.relayout(self)
-	
-	local doUpdate = false
-	
-	if self.dx ~= self.dx_target then
-		self.dx = math.floor(self.dx * (1 - self.scrollChangefactor) + self.dxTarget * self.scrollChangefactor)
-		doUpdate = true
+	if self.dx ~= self.dxTarget then
+		if math.abs(self.dx - self.dxTarget) > 1 then
+			self.dx = self.dx * (1 - self.scrollChangefactor) + self.dxTarget * self.scrollChangefactor
+		else
+			self.dx = self.dxTarget
+		end
 	end
+
+	Ui.relayout(self)
 	
 	self.scrollrect.x = self.screenx
 	self.scrollrect.y = self.screeny + self.h - self.scrollheight
@@ -236,10 +232,6 @@ function UiScrollAreaH:relayout()
 	self.clipRect.y = self.screeny
 	self.clipRect.w = self.w
 	self.clipRect.h = self.h
-	
-	if doUpdate then
-		Ui.mousemove(self, sdl.mouse.x(), sdl.mouse.y())
-	end
 end
 
 function UiScrollAreaH:mousedown(x, y, button)
@@ -277,8 +269,6 @@ function UiScrollAreaH:mousemove(x, y)
 	self.scrollHovered = y >= self.scrollrect.y
 
 	if self.scrollPressed then
-		self:relayout()
-
 		local ratio = (x - self.screenx - self.buttonwidth/2) / (self.w-self.buttonwidth)
 		if ratio < 0 then ratio = 0 end
 		if ratio > 1 then ratio = 1 end

--- a/scripts/mod_loader/ui/widgets/scrollarea.lua
+++ b/scripts/mod_loader/ui/widgets/scrollarea.lua
@@ -90,13 +90,6 @@ end
 
 function UiScrollArea:mousedown(x, y, button)
 	if x >= self.scrollrect.x then
-		if self.root.pressedchild ~= nil then
-			self.root.pressedchild.pressed = false
-		end
-
-		self.root.pressedchild = self
-		self.pressed = true
-
 		if self.innerHeight > self.h then
 			local ratio = (y - self.screeny - self.buttonheight/2) / (self.h - self.buttonheight)
 			if ratio < 0 then ratio = 0 end
@@ -114,13 +107,14 @@ end
 
 function UiScrollArea:mouseup(x, y, button)
 	self.scrollPressed = false
-
 	return Ui.mouseup(self, x, y, button)
 end
 
 function UiScrollArea:wheel(mx, my, y)
-	local upperlimit = math.max(0, self.innerHeight - self.h)
-	self.dyTarget = math.max(-self.scrollOvershoot, math.min(upperlimit + self.scrollOvershoot, self.dyTarget - y * self.scrollSpeed))
+	if not self.scrollPressed then
+		local upperlimit = math.max(0, self.innerHeight - self.h)
+		self.dyTarget = math.max(-self.scrollOvershoot, math.min(upperlimit + self.scrollOvershoot, self.dyTarget - y * self.scrollSpeed))
+	end
 
 	return Ui.wheel(self, mx, my, y)
 end
@@ -236,13 +230,6 @@ end
 
 function UiScrollAreaH:mousedown(x, y, button)
 	if y >= self.scrollrect.y then
-		if self.root.pressedchild ~= nil then
-			self.root.pressedchild.pressed = false
-		end
-
-		self.root.pressedchild = self
-		self.pressed = true
-
 		if self.innerWidth > self.w then
 			local ratio = (x - self.screenx - self.buttonwidth/2) / (self.w - self.buttonwidth)
 			if ratio < 0 then ratio = 0 end
@@ -259,8 +246,10 @@ function UiScrollAreaH:mousedown(x, y, button)
 end
 
 function UiScrollAreaH:wheel(mx, my, y)
-	local upperlimit = math.max(0, self.innerWidth - self.w)
-	self.dxTarget = math.max(-self.scrollOvershoot, math.min(upperlimit + self.scrollOvershoot, self.dxTarget - y * self.scrollSpeed))
+	if not self.scrollPressed then
+		local upperlimit = math.max(0, self.innerWidth - self.w)
+		self.dxTarget = math.max(-self.scrollOvershoot, math.min(upperlimit + self.scrollOvershoot, self.dxTarget - y * self.scrollSpeed))
+	end
 
 	return Ui.wheel(self, mx, my, y)
 end

--- a/scripts/mod_loader/ui/widgets/scrollarea.lua
+++ b/scripts/mod_loader/ui/widgets/scrollarea.lua
@@ -13,9 +13,10 @@ function UiScrollArea:new()
 	self.padr = self.padr + self.scrollwidth
 	self.nofity = true
 	self.dyTarget = 0
-	self.scrollSpeed = 100
-	self.scrollOvershoot = 0
-	self.scrollChangefactor = 0.4 -- <0.0, 1.0]
+	self.scrollDistance = 100
+	self.scrollOvershoot = 6
+	self.scrollChangeFactor = 0.6 -- <0.0, 1.0]
+	self.scrollReboundFactor = 0.4 -- <0.0, 1.0]
 
 	self.scrollPressed = false
 	self.scrollHovered = false
@@ -50,12 +51,10 @@ function UiScrollArea:draw(screen)
 end
 
 function UiScrollArea:relayout()
-	if self.dy ~= self.dyTarget then
-		if math.abs(self.dy - self.dyTarget) > 1 then
-			self.dy = self.dy * (1 - self.scrollChangefactor) + self.dyTarget * self.scrollChangefactor
-		else
-			self.dy = self.dyTarget
-		end
+	if math.abs(self.dy - self.dyTarget) > 1 then
+		self.dy = self.dy * (1 - self.scrollChangeFactor)  + self.dyTarget * self.scrollChangeFactor
+	else
+		self.dy = self.dyTarget
 	end
 
 	Ui.relayout(self)
@@ -67,9 +66,17 @@ function UiScrollArea:relayout()
 
 	local upperlimit = math.max(0, self.innerHeight - self.h)
 	if self.dy > upperlimit then
-		self.dyTarget = upperlimit
+		if self.dy - upperlimit > 1 then
+			self.dyTarget = self.dy * (1 - self.scrollReboundFactor) + upperlimit * self.scrollReboundFactor
+		else
+			self.dyTarget = upperlimit
+		end
 	elseif self.dy < 0 then
-		self.dyTarget = 0
+		if self.dy < -1 then
+			self.dyTarget = self.dy * (1 - self.scrollReboundFactor)
+		else
+			self.dyTarget = 0
+		end
 	end
 	
 	local ratio = self.h / self.innerHeight
@@ -113,7 +120,7 @@ end
 function UiScrollArea:wheel(mx, my, y)
 	if not self.scrollPressed then
 		local upperlimit = math.max(0, self.innerHeight - self.h)
-		self.dyTarget = math.max(-self.scrollOvershoot, math.min(upperlimit + self.scrollOvershoot, self.dyTarget - y * self.scrollSpeed))
+		self.dyTarget = math.max(-self.scrollOvershoot, math.min(upperlimit + self.scrollOvershoot, self.dyTarget - y * self.scrollDistance))
 	end
 
 	return Ui.wheel(self, mx, my, y)
@@ -153,9 +160,10 @@ function UiScrollAreaH:new()
 	self.padb = self.padb + self.scrollheight
 	self.nofitx = true
 	self.dxTarget = 0
-	self.scrollSpeed = 100
-	self.scrollOvershoot = 0
-	self.scrollChangefactor = 0.4 -- <0.0, 1.0]
+	self.scrollDistance = 100
+	self.scrollOvershoot = 6
+	self.scrollChangeFactor = 0.6 -- <0.0, 1.0]
+	self.scrollReboundFactor = 0.4 -- <0.0, 1.0]
 
 	self.scrollPressed = false
 	self.scrollHovered = false
@@ -190,12 +198,10 @@ function UiScrollAreaH:draw(screen)
 end
 
 function UiScrollAreaH:relayout()
-	if self.dx ~= self.dxTarget then
-		if math.abs(self.dx - self.dxTarget) > 1 then
-			self.dx = self.dx * (1 - self.scrollChangefactor) + self.dxTarget * self.scrollChangefactor
-		else
-			self.dx = self.dxTarget
-		end
+	if math.abs(self.dx - self.dxTarget) > 1 then
+		self.dx = self.dx * (1 - self.scrollChangeFactor) + self.dxTarget * self.scrollChangeFactor
+	else
+		self.dx = self.dxTarget
 	end
 
 	Ui.relayout(self)
@@ -207,9 +213,17 @@ function UiScrollAreaH:relayout()
 
 	local upperlimit = math.max(0, self.innerWidth - self.w)
 	if self.dx > upperlimit then
-		self.dxTarget = upperlimit
+		if self.dx > 1 then
+			self.dxTarget = self.dx * (1 - self.scrollReboundFactor) + upperlimit * self.scrollReboundFactor
+		else
+			self.dxTarget = upperlimit
+		end
 	elseif self.dx < 0 then
-		self.dxTarget = 0
+		if self.dx < -1 then
+			self.dxTarget = self.dx * (1 - self.scrollReboundFactor)
+		else
+			self.dxTarget = 0
+		end
 	end
 	
 	local ratio = self.w / self.innerWidth
@@ -248,7 +262,7 @@ end
 function UiScrollAreaH:wheel(mx, my, y)
 	if not self.scrollPressed then
 		local upperlimit = math.max(0, self.innerWidth - self.w)
-		self.dxTarget = math.max(-self.scrollOvershoot, math.min(upperlimit + self.scrollOvershoot, self.dxTarget - y * self.scrollSpeed))
+		self.dxTarget = math.max(-self.scrollOvershoot, math.min(upperlimit + self.scrollOvershoot, self.dxTarget - y * self.scrollDistance))
 	end
 
 	return Ui.wheel(self, mx, my, y)

--- a/scripts/mod_loader/ui/widgets/tooltip.lua
+++ b/scripts/mod_loader/ui/widgets/tooltip.lua
@@ -49,15 +49,24 @@ local function computeAlignedPos(self, widget, horizontal)
 end
 
 function UiTooltip:updateText()
-	if self.title ~= self.root.title or self.text ~= self.root.tooltip then
+	local title = self.root.tooltip_title or ""
+	local text = self.root.tooltip or ""
+	local isTitle = title ~= ""
+	local isText = text ~= ""
+
+	if self.ui_title.text ~= title or self.ui_text.text ~= text then
 		self.w = 0
-		self.ui_title:setText(self.root.tooltip_title)
-		self.ui_text:setText(self.root.tooltip)
+
+		if self.ui_title.text ~= title then
+			self.ui_title:setText(title)
+		end
+
+		if self.ui_text.text ~= text then
+			self.ui_text:setText(text)
+		end
+
 		self.w = math.max(self.ui_title:maxChildSize("width"), self.ui_text:maxChildSize("width")) + self.padl + self.padr
 	end
-
-	local isTitle = self.ui_title.text and self.ui_title.text ~= ""
-	local isText = self.ui_text.text and self.ui_text.text ~= ""
 
 	self.ui_title.visible = isTitle
 	self.ui_text.visible = isText
@@ -65,9 +74,6 @@ function UiTooltip:updateText()
 end
 
 function UiTooltip:relayout()
-	-- build the tooltip with the whole screen available
-	self.w = ScreenSizeX()
-	self.h = ScreenSizeY()
 	self:updateText()
 	UiBoxLayout.relayout(self)
 

--- a/scripts/mod_loader/ui/widgets/tooltip.lua
+++ b/scripts/mod_loader/ui/widgets/tooltip.lua
@@ -13,7 +13,9 @@ function UiTooltip:new()
 
 	self
 		:decorate({ DecoFrame(deco.colors.tooltipbg, deco.colors.white, 3) })
-		:padding(10)
+		-- set even combined padding (3+9=12)
+		-- to avoid fraction when divided by 2
+		:padding(9)
 		:vgap(5)
 	self.title = nil
 	self.text = nil


### PR DESCRIPTION
This is an attempt to streamline the ui system.

## Dropdowns
Are now added to a separate dropdownUi element in root, and has automatic cleanup on mousedown events if they ever get orphaned; but otherwise don't need any more special treatment.

## Draggable
Can now be added to a separate draggableUi element in root, in order for it to be drawn on top of most everything else (barring dropdowns and tooltips). Some functionality has also been added to UiDraggable, in order to streamline the process of creating windows that let you drag an element among a list of elements.

## UiRoot:updateStates()
This function runs each frame in order to update important variables in every descendant.

&nbsp;
## Ui.containsMouse
This variable is `true` if the element contains the mouse cursor; otherwise `false`
- This is ensured by the function `Ui.updateContainsMouse`

## Ui:updateContainsMouse(mx, my)
This function goes through every descendant ui element in order to update their `containsMouse` state.
- `containsMouse` is set to `true` if; the element contains the mouse and is `visible` and `not ignoreMouse`; otherwise false.
- `mouseEntered` or `mouseEntered` is called for the element when `containsMouse` state changes.
- When called from root, it is ensured to go through every element to make sure `containsMouse` is always up to date, as long as no ui element has overridden `updateContainsMouse` to break the search.

&nbsp;

## Ui.hovered
This variable should only ever be true for one element. It is the topmost hoverable element contained by the mouse cursor, _or_ the pressed element.
- In order for an element to be hoverable it must be `visible`, `not ignoreMouse`, `containsMouse` and `not translucent`
- However, a `translucent` element may be the ancestor of a hoverable element.

## Ui:updateHoveredState()
This function goes through every descendant ui element in order to update their `hovered` state.
- `UiRoot.updateHoveredState` is a separate function that resets the `hovered` state, and initiates the search for the hovered element by calling `Ui.updateHoveredState(root)`
- When iterating children, we know the first hoverable element we find will either be the first drawn element, or the ancestor of the first drawn element. With this knowledge, we can exit early, which means not all elements will be iterated.

&nbsp;

## UiRoot:updateDraggedState()
This function is kind of a hack. It checks if there is a `pressed` element, and if it is `draggable`. If there is, it calls `dragMove(mx, my)` for that element. It ensures dragged elements can make updates if the ui around them changes, even in the absence of mousemove events. There could possibly be another function called `dragUpdate` or similar to do the same task.
- There is no equivalent `Ui.updateDraggedState()` function

&nbsp;

## Ui:updateTooltipState()
This function is called for the `hovered` element, in order for that element to update the tooltip however it sees fit.
- `UiRoot.UpdateTooltipState` is a separate function that resets the tooltip, and calls `UpdateTooltipState` for the `hovered` element.

&nbsp;

## Ui:wheel()
If there is a `pressed` element, then `wheel` (and potentially `dragWheel`) is called for this element, and the mouse event is consumed if any of them returns `true`.

If the event was not consumed, then this function will be called for every ui element, as long as all of their ancestors are `visible`, `not ignoreMouse`, `containsMouse`. If any element returns `true`, the mouse event will be consumed, and the game will not execute this event in the vanilla game.
- `translucent` elements return `false`; otherwise `true`

&nbsp;

## Ui:mousedown() [**Edited**]
If the button is the left mousebutton, and there is a `hovered` element, `mousedown` will _only_ be called for this element (as well as any descendants), regardless of whether they consume the mouse event or not.

There is one exception to the first rule. Dropdowns that do not contain the mouse will recieve a `mousedown` call. This is to allow them to close themselves. Since this is an exception, their return value will not affect whether the mouse event is consumed or not.

If the event was not consumed, then this function will be called for every ui element, as long as all of their ancestors are `visible`, `not ignoreMouse`, `containsMouse`. If any element returns `true`, the mouse event will be consumed, and the game will not execute this event in the vanilla game.
- `translucent` elements return `false`; otherwise `true`

&nbsp;

## Ui:mouseup() [**Edited**]
If the button is the left mousebutton, and there is a `pressed` element, `mouseup` (and potentially `clicked`) will _only_ be called for this element (as well as any descendants), regardless of whether they consume the mouse event or not.

Otherwise, this function will be called for every ui element, as long as all of their ancestors are `visible`, `not ignoreMouse`, `containsMouse`. If any element returns `true`, the mouse event will be consumed, and the game will not execute this event in the vanilla game.
- `translucent` elements return `false`; otherwise `true`

&nbsp;

## Ui:mousemove()
If there is a `pressed` element, then `mousemove` (and potentially `dragMove`) is called for this element, and the mouse event is consumed if any of them returns `true`.

If the event was not consumed, then this function will be called for every ui element, as long as all of their ancestors are `visible`, `not ignoreMouse`, `containsMouse`. If any element returns `true`, the mouse event will be consumed, and the game will not execute this event in the vanilla game.
- `translucent` elements return `false`; otherwise `true`
