### PR TITLE
Fixed palette migration

### DIFF
--- a/scripts/mod_loader/modapi/palette.lua
+++ b/scripts/mod_loader/modapi/palette.lua
@@ -292,8 +292,6 @@ local function migrateColorMaps()
 	local fromIndex = PaletteDictionary:size() + 1
 	local toIndex = GetColorCount()
 
-	if fromIndex > toIndex then return end
-
 	for i = fromIndex, toIndex do
 		local colorMap = GetColorMap(i)
 		local id = VANILLA_PALETTE_ID[i] or getFurlId(i) or buildPaletteId()


### PR DESCRIPTION
When initializing a mod using FURL without adding a palette; GetColorMap and GetColorCount were not being properly set in the migrate function.