### PR TITLE
Fix current mission

### DIFF
--- a/scripts/mod_loader/altered/misc.lua
+++ b/scripts/mod_loader/altered/misc.lua
@@ -113,14 +113,6 @@ local function overrideNextPhase()
 	end
 end
 
-local function updateCurrentMission()
-	local region = GetCurrentRegion()
-	
-	if region then
-		modApi.current_mission = GAME:GetMission(region.mission)
-	end
-end
-
 local oldStartNewGame = startNewGame
 function startNewGame()
 
@@ -186,7 +178,6 @@ function LoadGame()
 
 	RestoreGameVariables(Settings)
 	overrideNextPhase()
-	updateCurrentMission()
 
 	if GAME.CustomDifficulty then
 		SetDifficulty(GAME.CustomDifficulty)

--- a/scripts/mod_loader/altered/misc.lua
+++ b/scripts/mod_loader/altered/misc.lua
@@ -105,7 +105,8 @@ local function overrideNextPhase()
 
 		if nxtId ~= "" then
 			-- Set the mission's id, since the game doesn't do it
-			local nextMission = _G[nxtId]
+			local id = self:GetMissionId(mission)
+			local nextMission = self.Missions[id]
 			nextMission.ID = nxtId
 
 			modApi:fireMissionNextPhaseCreatedHooks(prevMission, nextMission)

--- a/scripts/mod_loader/altered/missions.lua
+++ b/scripts/mod_loader/altered/missions.lua
@@ -67,6 +67,7 @@ end
 
 local oldBaseDeployment = Mission.BaseDeployment
 function Mission:BaseDeployment()
+	modApi:setMission(self)
 	oldBaseDeployment(self)
 	self.Board = Board
 
@@ -258,6 +259,7 @@ end
 
 function Mission_Test:BaseStart()
 	Board.isMission = true
+	modApi:setMission(self)
 	Mission.BaseStart(self, true)
 
 	modApi:fireTestMechEnteredHooks(self)
@@ -268,6 +270,7 @@ end
 function Mission_Test:MissionEnd()
 	-- DON'T call the default MissionEnd
 	-- Mission.MissionEnd(self)
+	modApi:setMission(nil)
 
 	modApi:fireTestMechExitedHooks(self)
 end

--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -43,6 +43,7 @@ t.onSettingsChanged = Event()
 t.onProfileChanged = Event()
 t.onProfileCreated = Event()
 t.onProfileDeleted = Event()
+t.onSaveDataUpdated = Event()
 
 t.onHangarUiShown = Event()
 t.onHangarUiHidden = Event()
@@ -77,6 +78,7 @@ t.onAbandonTimelineWindowHidden = Event()
 t.onStatusTooltipWindowShown = Event()
 t.onStatusTooltipWindowHidden = Event()
 
+t.onMissionChanged = Event()
 t.onGameVictory = Event()
 
 t.onShiftToggled = Event()

--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -43,7 +43,6 @@ t.onSettingsChanged = Event()
 t.onProfileChanged = Event()
 t.onProfileCreated = Event()
 t.onProfileDeleted = Event()
-t.onSaveDataUpdated = Event()
 
 t.onHangarUiShown = Event()
 t.onHangarUiHidden = Event()

--- a/scripts/mod_loader/modapi/__scripts.lua
+++ b/scripts/mod_loader/modapi/__scripts.lua
@@ -18,6 +18,7 @@ local scripts = {
 	"drops",
 	"difficulty",
 	"map",
+	"mission",
 	"skills",
 	"savedata",
 	"hotkey",

--- a/scripts/mod_loader/modapi/global.lua
+++ b/scripts/mod_loader/modapi/global.lua
@@ -53,13 +53,7 @@ function GetCurrentMission()
 		return Mission_Test
 	end
 
-	local region = GetCurrentRegion()
-
-	if region then
-		return GAME:GetMission(region.mission)
-	end
-
-	return nil
+	return modApi.current_mission
 end
 
 Emitter_Blank = Emitter:new({

--- a/scripts/mod_loader/modapi/global.lua
+++ b/scripts/mod_loader/modapi/global.lua
@@ -53,7 +53,13 @@ function GetCurrentMission()
 		return Mission_Test
 	end
 
-	return modApi.current_mission
+	local region = GetCurrentRegion()
+
+	if region then
+		return GAME:GetMission(region.mission)
+	end
+
+	return nil
 end
 
 Emitter_Blank = Emitter:new({

--- a/scripts/mod_loader/modapi/global.lua
+++ b/scripts/mod_loader/modapi/global.lua
@@ -34,9 +34,9 @@ end
 function IsTestMechScenario()
 	if not Game then return false end
 
-	local p0 = Game:GetPawn(0)
-	local p1 = Game:GetPawn(1)
-	local p2 = Game:GetPawn(2)
+	local p0 = Game:GetPawn(0) ~= nil
+	local p1 = Game:GetPawn(1) ~= nil
+	local p2 = Game:GetPawn(2) ~= nil
 
 	-- In test mech scenario, only one of the three
 	-- player mechs will not be nil.

--- a/scripts/mod_loader/modapi/mission.lua
+++ b/scripts/mod_loader/modapi/mission.lua
@@ -1,0 +1,34 @@
+
+function modApi:setMission(mission)
+	local oldMission = self.current_mission
+
+	if self.current_mission ~= mission then
+		self.current_mission = mission
+
+		modApi.events.onMissionChanged:dispatch(mission, oldMission)
+	end
+end
+
+local currentRegionData
+modApi.events.onSaveDataUpdated:subscribe(function()
+	local oldRegionData = currentRegionData
+
+	if currentRegionData ~= RegionData then
+		currentRegionData = RegionData
+
+		local region = GetCurrentRegion(RegionData)
+		local mission = nil
+
+		if region then
+			mission = GAME:GetMission(region.mission)
+		end
+
+		if not IsTestMechScenario() then
+			modApi:setMission(mission)
+		end
+	end
+end)
+
+modApi.events.onGameExited:subscribe(function()
+	modApi:setMission(nil)
+end)

--- a/scripts/mod_loader/modapi/mission.lua
+++ b/scripts/mod_loader/modapi/mission.lua
@@ -29,6 +29,10 @@ modApi.events.onSaveDataUpdated:subscribe(function()
 	end
 end)
 
+modApi.events.onMissionNextPhaseCreated:subscribe(function(prevMission, nextMission)
+	modApi:setMission(nextMission)
+end)
+
 modApi.events.onGameExited:subscribe(function()
 	modApi:setMission(nil)
 end)

--- a/scripts/mod_loader/modapi/savedata.lua
+++ b/scripts/mod_loader/modapi/savedata.lua
@@ -168,7 +168,6 @@ local function restoreGameVariables(settings)
 		RegionData = env.RegionData
 		SquadData = env.SquadData
 		
-		modApi.events.onSaveDataUpdated:dispatch()
 		modApi:fireSaveDataUpdatedHooks()
 	end
 end

--- a/scripts/mod_loader/modapi/savedata.lua
+++ b/scripts/mod_loader/modapi/savedata.lua
@@ -168,6 +168,7 @@ local function restoreGameVariables(settings)
 		RegionData = env.RegionData
 		SquadData = env.SquadData
 		
+		modApi.events.onSaveDataUpdated:dispatch()
 		modApi:fireSaveDataUpdatedHooks()
 	end
 end


### PR DESCRIPTION
Referencing issue #83

This is a proposed change to `GetCurrentMission`

The reason for wanting to fix `GetCurrentMission`, is that I wanted to create some functionality that relied on detecting the current mission, and the current implementation is not accurate enough for my purposes.

However, since this is an old function; and a lot of code may rely on the current implementation, I am open to it needing to remain unchanged.