### PR TITLE
Added modApi methods to fetch map data

### DIFF
--- a/scripts/mod_loader/modapi/map.lua
+++ b/scripts/mod_loader/modapi/map.lua
@@ -37,3 +37,108 @@ function modApi:addMap(path)
 		self:copyFile(path, "maps/"..mapfile)
 	end
 end
+
+local maps_cached
+
+function modApi:clearCachedMaps()
+	maps_cached = nil
+end
+
+function modApi:getMaps()
+	return maps_cached or self:fetchMaps()
+end
+
+function modApi:fetchMaps()
+	local files = mod_loader:enumerateFilesIn("maps/")
+	local maps = {}
+
+	for _, file in ipairs(files) do
+		if modApi:stringEndsWith(file, ".map") then
+			local map = {}
+			local id
+			modApi:loadIntoEnv("maps/"..file, map)
+			id, map = next(map)
+			map.id = id
+			maps[#maps+1] = map
+		end
+	end
+
+	return maps
+end
+
+local function filterMapsByIds(maps, ids)
+	local result = {}
+
+	for _, map in ipairs(maps) do
+		if list_contains(ids, map.id) then
+			result[#result+1] = map
+		end
+	end
+
+	return result
+end
+
+local function filterMapsByTags(maps, tags)
+	local result = {}
+
+	if type(tags) ~= 'table' then
+		tags = { tags }
+	end
+
+	for _, map in ipairs(maps) do
+		for _, tag in ipairs(map.tags) do
+			if list_contains(tags, tag) then
+				result[#result+1] = map
+				break
+			end
+		end
+	end
+
+	return result
+end
+
+local function filterMapsByTileset(maps, tileset)
+	local result = {}
+
+	for _, map in ipairs(maps) do
+		for _, tag in ipairs(map.tags) do
+			if tag == "any_sector" or tag == tileset then
+				result[#result+1] = map
+				break
+			end
+		end
+	end
+
+	return result
+end
+
+local function filterMapsByVetoes(maps, vetoes)
+	local result = {}
+
+	for _, map in ipairs(maps) do
+		if not list_contains(vetoes, map.id) then
+			result[#result+1] = map
+		end
+	end
+
+	return result
+end
+
+function modApi:fetchMissionMaps(mission, tileset)
+	Assert.Equals('string', type(mission), "Argument #1")
+	Assert.Equals('string', type(tileset), "Argument #2")
+	Assert.Equals('table', type(_G[mission]), "Mission '"..mission.."' does not exist")
+
+	local maps = self:getMaps()
+	local mission = _G[mission]
+
+	if #mission.MapList > 0 then
+		maps = filterMapsByIds(maps, mission.MapList)
+	else
+		maps = filterMapsByTags(maps, mission.MapTags)
+		maps = filterMapsByTileset(maps, tileset)
+		maps = filterMapsByVetoes(maps, mission.MapVetoes)
+	end
+
+	return maps
+end


### PR DESCRIPTION
Added methods:
- modApi:fetchMaps - returns a list of the map data of all maps.
- modApi:getMaps - same as fetchMaps, but returns the cached list of mapdata if available.
- modApi:fetchMissionMaps - returns a list of map data of all the maps available for this mission. Uses the cached mapdata list if available.
- modApi:clearCachedMaps - clears the cached mapdata list.