### PR TITLE
Added methods to personality metatable for adding dialog

### DIFF
--- a/scripts/mod_loader/modapi/__scripts.lua
+++ b/scripts/mod_loader/modapi/__scripts.lua
@@ -10,6 +10,7 @@ local scripts = {
 	"hooks",
 	"data",
 	"text",
+	"personalities",
 	"personalities_csv",
 	"achievement",
 	"medals",

--- a/scripts/mod_loader/modapi/personalities.lua
+++ b/scripts/mod_loader/modapi/personalities.lua
@@ -1,0 +1,54 @@
+
+-- substitute unreadable characters.
+local function formatTexts(texts)
+	Assert.Equals('table', type(texts), "Argument #1")
+
+	for i, text in ipairs(texts) do
+		text = string.gsub(text,"“","")
+		text = string.gsub(text,"”","")
+		text = string.gsub(text,"‘","'")
+		text = string.gsub(text,"…","...")
+		text = string.gsub(text,"’","'")
+		text = string.gsub(text,"–","-")
+		texts[i] = text
+	end
+end
+
+local function dialogEvent(event, texts, overwrite)
+	if type(texts) == 'string' then
+		texts = {texts}
+	end
+
+	formatTexts(texts)
+
+	if overwrite then
+		return texts
+	else
+		return add_arrays(event, texts)
+	end
+end
+
+local function addDialogTable(self, dialogTable, overwrite)
+	Assert.Equals('table', type(dialogTable), "Argument #1")
+
+	for event, texts in pairs(dialogTable) do
+		self[event] = self[event] or {}
+		self[event] = dialogEvent(self[event], texts, overwrite)
+	end
+end
+
+local function addMissionDialogTable(missionId, dialogTable, overwrite)
+	Assert.Equals('string', type(missionId), "Argument #1")
+	Assert.Equals('table', type(dialogTable), "Argument #2")
+
+	for event, texts in pairs(dialogTable) do
+		local event = missionId.."_"..event
+
+		self[event] = self[event] or {}
+		self[event] = dialogEvent(self[event], texts, overwrite)
+	end
+end
+
+local personality = getmetatable(Personality["Artificial"])
+personality.AddDialogTable = addDialogTable
+personality.AddMissionDialogTable = addMissionDialogTable


### PR DESCRIPTION
Added two methods to the personality metatable:
- AddDialogTable - adds a table of dialog to the personality
- AddMissionDialogTable - adds a table of dialog to the personality, where all the events are prefixed with mission id specified.

Syntax of dialog tables are as follows:
```lua
{
    Event_Singleline = "Text",
    Event_Multiline = {
        "Text1",
        "Text2",
        "Text3",
    }
}
```