### PR TITLE
Fixes the first created achievement to not revert to its initial state

### DIFF
--- a/scripts/mod_loader/modapi/achievement.lua
+++ b/scripts/mod_loader/modapi/achievement.lua
@@ -273,10 +273,6 @@ function Achievement:resetProgress()
 end
 
 function Achievement:getProgress()
-	if modApi.achievements.cachedProfileData == nil then
-		return self:getObjectiveInitialState()
-	end
-
 	return readData(self.mod_id, self.id)
 end
 


### PR DESCRIPTION
I do not know what the intention of this removed code was, but it looks all wrong.

If `modApi.achievements.cachedProfileData` is nil, `readData` will call `updateCachedProfileData` to initialize it. Returning the initial state of the achievement does not make any sense.

This fixes the issue where the first achievement created would revert to its initial state.