### PR TITLE
Fix Pawn:IsArmor to return false for any Psion

### DIFF
--- a/scripts/mod_loader/modapi/pawn.lua
+++ b/scripts/mod_loader/modapi/pawn.lua
@@ -123,12 +123,12 @@ BoardPawn.IsArmor = function(self)
 	local isArmoredPilotAbility = self:IsAbility("Armored")
 	local isArmoredPawn = pawnType:GetArmor()
 	local isArmoredMutation = self:IsMutation(LEADER_ARMOR)
-	local isEffectSource = pawnType:GetLeader() == LEADER_ARMOR
+	local isPsion = pawnType:GetLeader() ~= LEADER_NONE
 
 	-- TODO: Bug: killing an armor psion then respawning it via Board:AddPawn() causes this function to return false
 	-- Need to update the savefile after a new pawn appears on the board
 	
-	return isArmoredPilotAbility or isArmoredPawn or (isArmoredMutation and not isEffectSource)
+	return isArmoredPilotAbility or isArmoredPawn or (isArmoredMutation and not isPsion)
 end
 
 BoardPawn.IsIgnoreWeb = function(self)


### PR DESCRIPTION
Psions other than Shell Psion would previously return `true` from `Pawn:IsArmor()` if a Shell Psion was in effect.

Any unit that can give mutations, cannot gain any mutations.

Visually, it will look like a Psion can get mutations from other psions. `Pawn:IsMutation` will even return `true`. However, functionally, they will have no armor, or any other mutation affecting them.