### PR TITLE
Updated Pawn:GetPawnTable

### DIFF
--- a/scripts/mod_loader/modapi/pawn.lua
+++ b/scripts/mod_loader/modapi/pawn.lua
@@ -20,7 +20,7 @@ BoardPawn.GetPawnTable = function(self)
 	local region = GetCurrentRegion(RegionData)
 	
 	if region == nil then
-		return {}
+		return GetPawnTable(self:GetId()) or {}
 	end
 	
 	return GetPawnTable(self:GetId(), region.player.map_data) or {}


### PR DESCRIPTION
Updated `Pawn:GetPawnTable` to be able to fetch saved Mech data in Test Mech Scenario.