### PR TITLE
Added onPawnSelected and onPawnDeselected events

### DIFF
--- a/scripts/mod_loader/altered/skills.lua
+++ b/scripts/mod_loader/altered/skills.lua
@@ -176,6 +176,16 @@ end
 modApi.events.onFrameDrawStart:subscribe(function()
 	local selectedPawnIdCurrent = Board and Board:GetSelectedPawnId() or nil
 
+	if Game and selectedPawnIdCurrent ~= selectedPawnIdLast then
+		if selectedPawnIdLast then
+			modApi:firePawnDeselectedHooks(Game:GetPawn(selectedPawnIdLast))
+		end
+
+		if selectedPawnIdCurrent then
+			modApi:firePawnSelectedHooks(Game:GetPawn(selectedPawnIdCurrent))
+		end
+	end
+
 	if focusedPawnCurrent ~= focusedPawnLast or selectedPawnIdCurrent ~= selectedPawnIdLast then
 		if focusedPawnLast then
 			modApi:firePawnUnfocusedHooks(focusedPawnLast)

--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -165,6 +165,8 @@ local hooks = {
 	"TipImageHidden",
 	"PawnFocused",
 	"PawnUnfocused",
+	"PawnSelected",
+	"PawnDeselected",
 }
 
 for _, name in ipairs(hooks) do


### PR DESCRIPTION
Events are added into the same loop that handles `onPawnFocused` and `onPawnUnfocused` events, because the loop already fetches the information about the selected pawn every frame.

Due to how exiting a run to the main menu causes both `Game` and `Board` to seize to exist, `onPawnDeselected` will not be dispatched if doing so while a pawn is selected.

The alternative was to dispatch with the pawn id as argument instead. Both variants have some merit.

The current way will require the user to subscribe to an `onGameExited` event to free up anything if `onPawnSelected` and `onPawnDeselected` are working in tandem.