### PR TITLE
Added BoardPawn.GetAbility

### DIFF
--- a/scripts/mod_loader/modapi/pawn.lua
+++ b/scripts/mod_loader/modapi/pawn.lua
@@ -241,6 +241,19 @@ BoardPawn.IsHighlighted = function(self)
 	return false
 end
 
+BoardPawn.GetAbility = function(self)
+	Assert.Equals("userdata", type(self), "Argument #0")
+
+	local ptable = self:GetPawnTable()
+
+	if ptable.pilot == nil then
+		return ""
+	end
+
+	local pilot = _G[ptable.pilot.id]
+	return pilot.Skill
+end
+
 BoardPawn.GetLuaString = function(self)
 	Assert.Equals("userdata", type(self), "Argument #0")
 	return string.format("BoardPawn [id = %s, space = %s, name = %s]", self:GetId(), self:GetSpace():GetLuaString(), self:GetMechName())
@@ -281,6 +294,9 @@ local function initializeBoardPawn()
 
 		setSavefileFieldsForPawn(self, { bPowered = powered })
 	end
+
+	BoardPawn.IsPilotSkill = pawn.IsAbility
+	BoardPawn.GetPilotSkill = pawn.GetAbility
 
 	pawn = nil
 	InitializeBoardPawn = nil


### PR DESCRIPTION
## Added methods:
- `BoardPawn.GetAbility`
- `BoardPawn.GetPilotSkill` - more clearly named variant of `BoardPawn.GetAbility`
- `BoardPawn:IsPilotSkill` - more clearly named variant of `BoardPawn.IsAbility`

## BoardPawn.GetAbility
- If the pawn has a pilot, it returns its pilot skill.
- If the pilot has no skill, it returns an empty string.
- If the pawn has no pilot, it returns an empty string.

It could be argued that it should return `nil` instead of an empty string. However, `BoardPawn:IsAbility("")` returns `true` for both pilots with no pilot skill, and pawns with no pilots, and `false` for any other string in those two cases.