### PR TITLE
Various fixes and improvements

### DIFF
--- a/scripts/mod_loader/bootstrap/assert.lua
+++ b/scripts/mod_loader/bootstrap/assert.lua
@@ -38,6 +38,11 @@ local function has_equal(expected, actual)
 	return expected == actual
 end
 
+function Assert.Error(msg)
+	msg = (msg and msg .. ": ") or ""
+	error(msg..traceback())
+end
+
 function Assert.Equals(expected, actual, msg)
 	msg = (msg and msg .. ": ") or ""
 	msg = msg .. string.format("Expected %s, but was '%s'%s", get_string(expected), tostring(actual), traceback())

--- a/scripts/mod_loader/sdlext/extensions.lua
+++ b/scripts/mod_loader/sdlext/extensions.lua
@@ -209,13 +209,6 @@ function drawtri_br(screen, color, rect)
 	end
 end
 
-local function rect_contains0(x, y, w, h, px, py)
-	return px >= x     and
-	       px < x + w  and
-	       py >= y     and
-	       py < y + h
-end
-
 --[[
 	rect_contains(rect, px, py)
 	OR
@@ -223,24 +216,17 @@ end
 --]]
 function rect_contains(...)
 	local a = {...}
-	Assert.True(#a == 3 or #a == 6, "Expected 3 or 6 arguments, but got " .. #a)
-
 	if #a == 3 then
-		return rect_contains0(
-			a[1].x, a[1].y,
-			a[1].w, a[1].h,
-			a[2],   a[3]
-		)
-	else
-		return rect_contains0(...)
+		return a[1]:contains(a[2], a[3])
+	elseif #a == 6 then
+		return sdl.rect(a[1], a[2], a[3], a[4]):contains(a[5], a[6])
 	end
+
+	Assert.Error("Expected 3 or 6 arguments, but got " .. tostring(#a))
 end
 
 function rect_intersects(r1, r2)
-	return not (r2.x >= r1.x + r1.w or
-	            r2.x + r2.w <= r1.x or
-	            r2.y >= r1.y + r1.h or
-	            r2.y + r2.h <= r1.y)
+	return r1:intersects(r2)
 end
 
 --[[

--- a/scripts/mod_loader/sdlext/extensions.lua
+++ b/scripts/mod_loader/sdlext/extensions.lua
@@ -219,7 +219,13 @@ function rect_contains(...)
 	if #a == 3 then
 		return a[1]:contains(a[2], a[3])
 	elseif #a == 6 then
-		return sdl.rect(a[1], a[2], a[3], a[4]):contains(a[5], a[6])
+		if not temprect then temprect = sdl.rect(0,0,0,0) end
+		temprect.x = a[1]
+		temprect.y = a[2]
+		temprect.w = a[3]
+		temprect.h = a[4]
+
+		return temprect:contains(a[5], a[6])
 	end
 
 	Assert.Error("Expected 3 or 6 arguments, but got " .. tostring(#a))

--- a/scripts/mod_loader/ui/widgets/base.lua
+++ b/scripts/mod_loader/ui/widgets/base.lua
@@ -325,13 +325,7 @@ function Ui:updateContainsMouse(mx, my)
 	if not self.visible or self.ignoreMouse then
 		curr_containsMouse = false
 	else
-		curr_containsMouse = rect_contains(
-			self.screenx,
-			self.screeny,
-			self.w,
-			self.h,
-			mx, my
-		)
+		curr_containsMouse = self.rect:contains(mx, my)
 	end
 
 	if curr_containsMouse ~= self.containsMouse then

--- a/scripts/mod_loader/ui/widgets/dragdroplist.lua
+++ b/scripts/mod_loader/ui/widgets/dragdroplist.lua
@@ -50,7 +50,6 @@ end
 
 function UiDragDropList:keydown(keycode)
 	if keycode == SDLKeycodes.ESCAPE then
-		self:stopDrag(sdl.mouse.x(), sdl.mouse.y(), 1)
 		self.root:setPressedChild(nil)
 		self.root:setDraggedChild(nil)
 	end

--- a/scripts/mod_loader/ui/widgets/dragdroplist.lua
+++ b/scripts/mod_loader/ui/widgets/dragdroplist.lua
@@ -53,6 +53,10 @@ function UiDragDropList:stopDrag(mx, my, button)
 	UiDraggable.stopDrag(self, mx, my, button)
 end
 
+function UiDragDropList:setfocus()
+	return false
+end
+
 function UiDragDropList:keydown(keycode)
 	if keycode == SDLKeycodes.ESCAPE then
 		self.root:setPressedChild(nil)
@@ -71,6 +75,7 @@ function Ui:registerDragDropList(placeholder)
 	self.dragPlaceholder = placeholder
 	self.startDrag = UiDragDropList.startDrag
 	self.stopDrag = UiDragDropList.stopDrag
+	self.setfocus = UiDragDropList.setfocus
 	self.keydown = UiDragDropList.keydown
 	self.keyup = UiDragDropList.keyup
 end

--- a/scripts/mod_loader/ui/widgets/dragdroplist.lua
+++ b/scripts/mod_loader/ui/widgets/dragdroplist.lua
@@ -36,6 +36,7 @@ function UiDragDropList:stopDrag(mx, my, button)
 	end
 
 	if self.dragMoving and self.dragPlaceholder ~= nil then
+		local root = self.root
 		local index = list_indexof(self.owner.children, self.dragPlaceholder)
 		self.dragPlaceholder:detach()
 		self.dragPlaceholder:hide()
@@ -43,6 +44,10 @@ function UiDragDropList:stopDrag(mx, my, button)
 		self:detach()
 		self:addTo(self.owner, index)
 		self.translucent = self.dragPlaceholder.translucent
+
+		if root then
+			root:setfocus(self.owner)
+		end
 	end
 
 	UiDraggable.stopDrag(self, mx, my, button)

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -65,12 +65,11 @@ function UiRoot:relayoutTooltipUi()
 end
 
 function UiRoot:setfocus(newfocus)
-	assert(
-		-- we permit the focus to be set to nil, ui elements with a parent,
-		-- or to the root itself
-		newfocus == nil or (newfocus.parent or newfocus.root == newfocus),
-		"Unable to set focus, because the UI element has no parent"
-	)
+	-- we permit the focus to be set to nil, ui elements with a parent,
+	-- or to the root itself
+	if newfocus and newfocus ~= self and newfocus.parent == nil then
+		newfocus = self
+	end
 
 	-- clear old focus
 	local p = self.focuschild

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -23,6 +23,15 @@ function UiRoot:new()
 	self.dropdownUi = PriorityUi():addTo(self.priorityUi)
 end
 
+function UiRoot:relayout()
+	self.rect.x = self.screenx
+	self.rect.y = self.screeny
+	self.rect.w = self.w
+	self.rect.h = self.h
+
+	Ui.relayout(self)
+end
+
 function UiRoot:draw(screen)
 	-- priorityUi is relayed out last, but drawn first
 	self.priorityUi.visible = false

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -47,6 +47,7 @@ function UiRoot:draw(screen)
 	self:relayoutTooltipUi()
 
 	Ui.draw(self, screen)
+	screen:clearmask()
 end
 
 function UiRoot:relayoutDragDropPriorityUi()

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -244,7 +244,9 @@ function UiRoot:event(eventloop)
 			pressedchild:mouseup(mx, my, button)
 		end
 
-		self:setfocus(hoveredchild)
+		if hoveredchild then
+			hoveredchild:setfocus()
+		end
 
 		if button == 1 and hoveredchild then
 			self:setPressedChild(hoveredchild)

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -235,6 +235,11 @@ function UiRoot:event(eventloop)
 		local button = eventloop:mousebutton()
 		local pressedchild = self.pressedchild
 		local hoveredchild = self.hoveredchild
+
+		if hoveredchild then
+			hoveredchild:setfocus()
+		end
+
 		local consumeEvent = self:mousedown(mx, my, button)
 
 		self:setDraggedChild(nil)
@@ -242,10 +247,6 @@ function UiRoot:event(eventloop)
 		if pressedchild then
 			self:setPressedChild(nil)
 			pressedchild:mouseup(mx, my, button)
-		end
-
-		if hoveredchild then
-			hoveredchild:setfocus()
 		end
 
 		if button == 1 and hoveredchild then

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -215,9 +215,9 @@ function UiRoot:event(eventloop)
 	
 	if type == sdl.events.mousewheel then
 		local wheel = eventloop:wheel()
-		local consumeEvent = self:wheel(mx, my, wheel)
 		local pressedchild = self.pressedchild
 		local draggedchild = self.draggedchild
+		local consumeEvent = self:wheel(mx, my, wheel)
 
 		-- pressedchild.wheel must have already been
 		-- called if this element contains the mouse.
@@ -234,7 +234,6 @@ function UiRoot:event(eventloop)
 
 	if type == sdl.events.mousebuttondown then
 		local button = eventloop:mousebutton()
-		local draggedchild = self.draggedchild
 		local pressedchild = self.pressedchild
 		local hoveredchild = self.hoveredchild
 		local consumeEvent = self:mousedown(mx, my, button)
@@ -273,7 +272,6 @@ function UiRoot:event(eventloop)
 	if type == sdl.events.mousebuttonup then
 		local button = eventloop:mousebutton()
 		local pressedchild = self.pressedchild
-		local draggedchild = self.draggedchild
 		local consumeEvent = self:mouseup(mx, my, button)
 
 		if button == 1 and pressedchild then

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -131,22 +131,39 @@ function UiRoot:setPressedChild(child)
 	end
 end
 
+-- Hack: always call startDrag and stopDrag
+-- with argument button = 1
 function UiRoot:setDraggedChild(child)
 	if self.draggedchild then
 		self.draggedchild.dragged = false
+		self.draggedchild:stopDrag(sdl.mouse.x(), sdl.mouse.y(), 1)
 	end
 
 	self.draggedchild = child
 
 	if child then
 		child.dragged = true
+		child:startDrag(sdl.mouse.x(), sdl.mouse.y(), 1)
 	end
 end
 
 function UiRoot:updatePressedState(mx, my)
+	local draggedchild = self.draggedchild
+	local pressedchild = self.pressedchild
+
 	-- release the pressed element if it has become orphaned from root
-	if self.pressedchild and self.pressedchild.root ~= self then
-		self:releasePressedchild(mx, my, 1)
+	if pressedchild and pressedchild.root ~= self then
+
+		if draggedchild then
+			self:setDraggedChild(nil)
+
+			-- Hack: always call stopDrag with argument button = 1
+			draggedchild:stopDrag(mx, my, 1)
+		end
+
+		self:setPressedChild(nil)
+
+		pressedchild:mouseup(mx, my, button)
 	end
 end
 
@@ -189,48 +206,6 @@ function UiRoot:updateStates()
 	self:updateState()
 end
 
-function UiRoot:pressHoveredchild(mx, my, button)
-	local pressedchild = self.hoveredchild
-	if pressedchild == nil then return end
-
-	self:setPressedChild(pressedchild)
-
-	if pressedchild.draggable then
-		self:setDraggedChild(pressedchild)
-		pressedchild:startDrag(mx, my, button)
-	end
-
-	return pressedchild:mousedown(mx, my, button)
-end
-
-function UiRoot:releasePressedchild(mx, my, button)
-	local draggedchild = self.draggedchild
-	local pressedchild = self.pressedchild
-
-	if draggedchild then
-		self:setDraggedChild(nil)
-
-		-- Hack: always call stopDrag with argument button = 1
-		draggedchild:stopDrag(mx, my, 1)
-	end
-
-	if pressedchild then
-		self:setPressedChild(nil)
-
-		if button == 1 then
-			local consumeEvent = pressedchild:mouseup(mx, my, button)
-
-			if pressedchild.containsMouse and pressedchild:clicked(button) then
-				consumeEvent = true
-			end
-
-			return consumeEvent
-		end
-	end
-
-	return false
-end
-
 function UiRoot:event(eventloop)
 	if not self.visible then return false end
 	
@@ -239,33 +214,46 @@ function UiRoot:event(eventloop)
 	local my = sdl.mouse.y()
 	
 	if type == sdl.events.mousewheel then
-		local pressedchild = self.pressedchild
 		local wheel = eventloop:wheel()
+		local consumeEvent = self:wheel(mx, my, wheel)
+		local pressedchild = self.pressedchild
+		local draggedchild = self.draggedchild
 
-		if pressedchild then
-			local consumeEvent = pressedchild:wheel(mx, my, wheel)
-
-			if self.draggedchild and self.draggedchild:dragWheel(mx, my, wheel) then
-				consumeEvent = true
-			end
-
-			if consumeEvent then
-				return true
-			end
+		-- pressedchild.wheel must have already been
+		-- called if this element contains the mouse.
+		if pressedchild and not pressedchild.containsMouse and pressedchild:wheel(mx, my, wheel) then
+			consumeEvent = true
 		end
 
-		return self:wheel(mx, my, wheel)
+		if draggedchild and draggedchild:dragWheel(mx, my, wheel) then
+			consumeEvent = true
+		end
+
+		return consumeEvent
 	end
 
 	if type == sdl.events.mousebuttondown then
 		local button = eventloop:mousebutton()
-		local consumeEvent = false
+		local draggedchild = self.draggedchild
+		local pressedchild = self.pressedchild
+		local hoveredchild = self.hoveredchild
+		local consumeEvent = self:mousedown(mx, my, button)
 
-		self:releasePressedchild(mx, my, button)
-		self:setfocus(self.hoveredchild)
+		self:setDraggedChild(nil)
 
-		if button == 1 then
-			consumeEvent = self:pressHoveredchild(mx, my, button)
+		if pressedchild then
+			self:setPressedChild(nil)
+			pressedchild:mouseup(mx, my, button)
+		end
+
+		self:setfocus(hoveredchild)
+
+		if button == 1 and hoveredchild then
+			self:setPressedChild(hoveredchild)
+
+			if hoveredchild.draggable then
+				self:setDraggedChild(hoveredchild)
+			end
 		end
 
 		-- inform open dropDownUi's of mouse down event,
@@ -277,10 +265,6 @@ function UiRoot:event(eventloop)
 			end
 		end
 
-		if not consumeEvent then
-			consumeEvent = self:mousedown(mx, my, button)
-		end
-
 		self:cleanupDropdown()
 
 		return consumeEvent
@@ -288,30 +272,48 @@ function UiRoot:event(eventloop)
 	
 	if type == sdl.events.mousebuttonup then
 		local button = eventloop:mousebutton()
+		local pressedchild = self.pressedchild
+		local draggedchild = self.draggedchild
+		local consumeEvent = self:mouseup(mx, my, button)
 
-		if button == 1 and self.pressedchild then
-			return self:releasePressedchild(mx, my, button)
+		if button == 1 and pressedchild then
+			self:setDraggedChild(nil)
+			self:setPressedChild(nil)
+
+			if pressedchild.containsMouse then
+				if pressedchild:clicked(button) then
+					consumeEvent = true
+				end
+			else
+				-- pressedchild.mouseup must have already been
+				-- called if this element contains the mouse.
+				if pressedchild:mouseup(mx, my, button) then
+					consumeEvent = true
+				end
+			end
 		end
 
-		return self:mouseup(mx, my, button)
+		return consumeEvent
 	end
 	
 	if type == sdl.events.mousemotion then
 		local pressedchild = self.pressedchild
+		local draggedchild = self.draggedchild
+		local consumeEvent = self:mousemove(mx, my)
 
 		if pressedchild then
-			local consumeEvent = pressedchild:mousemove(mx, my)
-
-			if self.draggedchild and self.draggedchild:dragMove(mx, my) then
+			if draggedchild and draggedchild:dragMove(mx, my) then
 				consumeEvent = true
 			end
 
-			if consumeEvent then
-				return true
+			-- pressedchild.mousemove must have already been
+			-- called if this element contains the mouse.
+			if not pressedchild.containsMouse and pressedchild:mousemove(mx, my) then
+				consumeEvent = true
 			end
 		end
 
-		return self:mousemove(mx, my)
+		return consumeEvent
 	end
 
 	if type == sdl.events.keydown then

--- a/scripts/mod_loader/ui/widgets/root.lua
+++ b/scripts/mod_loader/ui/widgets/root.lua
@@ -240,8 +240,6 @@ function UiRoot:event(eventloop)
 			hoveredchild:setfocus()
 		end
 
-		local consumeEvent = self:mousedown(mx, my, button)
-
 		self:setDraggedChild(nil)
 
 		if pressedchild then
@@ -256,6 +254,8 @@ function UiRoot:event(eventloop)
 				self:setDraggedChild(hoveredchild)
 			end
 		end
+
+		local consumeEvent = self:mousedown(mx, my, button)
 
 		-- inform open dropDownUi's of mouse down event,
 		-- even if the mouse click was outside of its area,


### PR DESCRIPTION
This PR intends to fix issues #100, #102 and #108 in relation mouse event handling.

Misc additions:
e498a80 adds a call to `screen.clearmask` to allow for mod loader and mods to use `screen.mask` and `screen.unmask` to more easily define complex draw areas.

4693c75 fixes an issue where pressing escape would fall through to the vanilla game after dragging a `draggable` element (pilot/palette)

c35dc71 changes `Ui.updateContainsMouse` to call `sdl.rect.contains` to improve performance.

56fe0fa updated `rect_contains` and `rect_intersects` to call `sdl.rect` methods for better performance.

e39e847 adds `Assert.Error` - similar to `error`, but with conditional `debug.traceback` for better debugging.

f17d948 changes `UiRoot.setfocus` to handle the case when attempting to focus an element without a parent. In such a case, focus will be set to the root itself.