### PR TITLE
Added the ability for mods to be disabled by default

### DIFF
--- a/scripts/mod_loader/mod_loader.lua
+++ b/scripts/mod_loader/mod_loader.lua
@@ -264,7 +264,7 @@ function mod_loader:enumerateMods(dirPathRelativeToGameDir, parentMod)
 			
 			self.mod_options[data.id] = {
 				options = {},--For configurable mods
-				enabled = true,
+				enabled = data.enabled == nil and true or data.enabled,
 				version = data.version,
 			}
 			
@@ -412,7 +412,7 @@ function mod_loader:initMetadata(id)
 end
 
 function mod_loader:hasMod(id)
-	return self.mods[id] and self.mod_options[id].enabled
+	return self.mods[id]
 end
 
 function mod_loader:getModContentDefaults()
@@ -420,7 +420,7 @@ function mod_loader:getModContentDefaults()
 	
 	for id, mod in pairs(self.mod_options) do
 		if self:hasMod(id) then
-			local new = { enabled = true, version = mod.version, options = {} }
+			local new = { enabled = mod.enabled, version = mod.version, options = {} }
 			
 			--Convert from array (for order) to keyed (for save game)
 			for i, option in ipairs(mod.options) do

--- a/scripts/mod_loader/modui/mod_configuration.lua
+++ b/scripts/mod_loader/modui/mod_configuration.lua
@@ -70,14 +70,12 @@ local function buildNewModContent()
 			version = entry.version
 		}
 		
-		if modContent[id].enabled then
-			for i, opt in ipairs(entry.options) do
-				local opt_editable = entry_editable.options[i]
-				if opt.type == "checkbox" then
-					options[opt.id] = { enabled = opt_editable.enabled }
-				else
-					options[opt.id] = { value = opt_editable.value }
-				end
+		for i, opt in ipairs(entry.options) do
+			local opt_editable = entry_editable.options[i]
+			if opt.type == "checkbox" then
+				options[opt.id] = { enabled = opt_editable.enabled }
+			else
+				options[opt.id] = { value = opt_editable.value }
 			end
 		end
 	end


### PR DESCRIPTION
This PR intends to allow what was proposed in issue #96.

Changed mods from always being enabled by default when enumerated for the first time, to reading the mod's optional field `enabled`.

In order for mod config for disabled mods to be enumerated, `mod_loader:hasMod` has been changed to not check if the mod is enabled to return `true` for that mod id.

Commit 4f90231: Previously `mod_loader.currentModContent` would contain option entries for all mods on mod loader initialization, but those entries would be removed after exiting the dialog "Configure Mods". This commit updates the dialog to save the option entries for all mods when exiting the dialog. This also causes options for disabled mods to be remembered by the mod loader.