### PR TITLE
Feature/mod options

### DIFF
--- a/scripts/mod_loader/mod_loader.lua
+++ b/scripts/mod_loader/mod_loader.lua
@@ -412,7 +412,7 @@ function mod_loader:initMetadata(id)
 end
 
 function mod_loader:hasMod(id)
-	return self.mods[id]
+	return self.mods[id] and true or false
 end
 
 function mod_loader:getModContentDefaults()

--- a/scripts/mod_loader/modapi/misc.lua
+++ b/scripts/mod_loader/modapi/misc.lua
@@ -65,3 +65,9 @@ function modApi:addGenerationOption(id, name, tip, data)
 
 	table.insert(mod_loader.mod_options[self.currentMod].options, option)
 end
+
+function modApi:getCurrentMod()
+	Assert.ModInitializingOrLoading("This function should only be called while mods are initializing or loading")
+
+	return mod_loader.mods[self.currentMod]
+end

--- a/scripts/mod_loader/modapi/misc.lua
+++ b/scripts/mod_loader/modapi/misc.lua
@@ -71,3 +71,17 @@ function modApi:getCurrentMod()
 
 	return mod_loader.mods[self.currentMod]
 end
+
+function modApi:getModOptions(modId)
+	Assert.Equals({"string", "nil"}, type(modId), "Argument #1")
+
+	if modId == nil then
+		Assert.ModInitializingOrLoading("Argument #1 must be specified outside of init or load")
+		modId = mod_loader.currentMod
+	end
+
+	Assert.True(mod_loader:hasMod(modId), "Mod not found")
+
+	local modContent = mod_loader.currentModContent or mod_loader:getModConfig()
+	return modContent[modId].options
+end


### PR DESCRIPTION
## Fix
- `modApi:hasMod` - now returns a boolean as the function used to do

## New
- `modApi:getCurrentMod` - returns the mod table of the current initializing or loading mod
- `modApi:getModOptions` - return the mod options of the specified mod (solves #118 )

Documentation of each function can be found in the respective commits.