### PR TITLE
Fix `modApi.current_mission` being reset to nil when updating save data in a MissionStart event listener

### DIFF
--- a/scripts/mod_loader/altered/missions.lua
+++ b/scripts/mod_loader/altered/missions.lua
@@ -79,6 +79,7 @@ function Mission:BaseDeployment()
 	self.Board = Board
 
 	modApi:fireMissionStartHooks(self)
+	self.Deployed = true
 end
 
 local function overrideMissionEnd(self)
@@ -95,6 +96,7 @@ local oldCreateMission = CreateMission
 function CreateMission(mission)
 	local mObject = oldCreateMission(mission)
 	mObject.Initialized = false
+	mObject.Deployed = false
 
 	overrideMissionEnd(mObject)
 

--- a/scripts/mod_loader/modapi/mission.lua
+++ b/scripts/mod_loader/modapi/mission.lua
@@ -11,8 +11,6 @@ end
 
 local currentRegionData
 modApi.events.onSaveDataUpdated:subscribe(function()
-	local oldRegionData = currentRegionData
-
 	if currentRegionData ~= RegionData then
 		currentRegionData = RegionData
 
@@ -21,6 +19,18 @@ modApi.events.onSaveDataUpdated:subscribe(function()
 
 		if region then
 			mission = GAME:GetMission(region.mission)
+		end
+
+		if not region and modApi.current_mission and not modApi.current_mission.Deployed then
+			-- When updating the save file in MissionStart event listener (ie, from
+			-- Mission:BaseDeployment context), RegionData doesn't have `iBattleRegion` entry yet,
+			-- so we have no way of finding the current region/mission, and end up setting current
+			-- mission to nil.
+			-- To fix this, keep track of missions that are past the deployment phase with `Deployed`
+			-- flag, and check if the mission we have saved currently is already past that phase.
+			-- This way we know that we've been called from within BaseDeployment context, and don't
+			-- execute this block eg. when leaving a mission, which would be incorrect behaviour.
+			mission = modApi.current_mission
 		end
 
 		if not IsTestMechScenario() then


### PR DESCRIPTION
Fixes #123