### PR TITLE
Changing notify to use xpcall with stacktrace on failure

### DIFF
--- a/scripts/mod_loader/bootstrap/event.lua
+++ b/scripts/mod_loader/bootstrap/event.lua
@@ -128,6 +128,9 @@ function Event:new(options)
 		if options[Event.SHORTCIRCUIT] then
 			self.options[Event.SHORTCIRCUIT] = true
 		end
+		if options.eventName then
+			self.eventName = options.eventName
+		end
 	end
 end
 
@@ -220,16 +223,16 @@ function Event:unsubscribeAll()
 	end
 end
 
-local function isStackOverflowError(err)
+function Event.isStackOverflowError(err)
 	return string.find(err, "C stack overflow")
 end
 
-local function splitTrace(trace)
+function Event.splitTrace(trace)
     local firstLine, rest = trace:match("([^\n]+)\n?(.*)")
     return firstLine, rest
 end
 
-local function stripAfterXpcall(trace)
+function Event.stripAfterXpcall(trace)
     local out = {}
     for line in trace:gmatch("[^\n]+") do
         if line:find("%[C%]: in function 'xpcall'") then
@@ -240,16 +243,44 @@ local function stripAfterXpcall(trace)
     return table.concat(out, "\n")
 end
 
-local function buildErrorMessage(headerMessage, errorOrResult, subscriptionCaller, dispatchCaller)
-	local firstLine, rest = splitTrace(errorOrResult)
+function Event.tryExtractFireXxxxHooks(line)
+    -- captures: fire + anything + Hooks
+    return line:match("in function '(fire.*Hooks)'")
+end
+
+function Event.findFireXxxxHooks(trace)
+    for line in trace:gmatch("[^\n]+") do
+        local fn = Event.tryExtractFireXxxxHooks(line)
+        if fn then
+            return fn
+        end
+    end
+    return nil
+end
+
+function Event.buildErrorMessage(headerMessage, errorOrResult, fireFnName, subscriptionCaller, dispatchCaller)
+	fireFnName = fireFnName or Event.findFireXxxxHooks(dispatchCaller) or "<unable to determine>"
+	local firstLine, rest = Event.splitTrace(errorOrResult)
 	return string.format(
-			"%s%s\n- Call trace: \n    %s\n- Subscribed at: %s\n- Dispatched at: %s",
+			"%s%s\n- Event\\Hook: %s\n- Call trace: \n    %s\n- Subscribed at: %s\n- Dispatched at: %s",
 			headerMessage,
 			firstLine,
-			string.gsub(stripAfterXpcall(rest), "\n", "\n    "),
+			fireFnName,
+			string.gsub(Event.stripAfterXpcall(rest), "\n", "\n    "),
 			string.gsub(subscriptionCaller, "\n", "\n    "),
 			string.gsub(dispatchCaller, "\n", "\n    ")
 	)
+end
+
+function Event:handleFailure(errorOrResult, creator, caller)
+	errorOrResult = errorOrResult or "<unspecified error>"
+	local message = self.buildErrorMessage("An event callback failed: ", errorOrResult, 
+			self.eventName, creator, caller)
+	if Event.isStackOverflowError(errorOrResult) then
+		error(message)
+	else
+		LOG(message)
+	end
 end
 
 --- Fires this event, notifying all subscribers and passing all arguments
@@ -265,13 +296,8 @@ function Event:dispatch(...)
 	for _, sub in ipairs(snapshot) do
 		local ok, errorOrResult = sub:notify(args)
 
-		if not ok and errorOrResult then
-			local message = buildErrorMessage("An event callback failed: ", errorOrResult, sub.creator, caller)
-			if isStackOverflowError(errorOrResult) then
-				error(message)
-			else
-				LOG(message)
-			end
+		if not ok then
+			self:handleFailure(errorOrResult, sub.creator, caller)
 		elseif ok then
 			if errorOrResult and self.options[Event.SHORTCIRCUIT] then
 				return true

--- a/scripts/mod_loader/bootstrap/event.lua
+++ b/scripts/mod_loader/bootstrap/event.lua
@@ -50,13 +50,24 @@ end
 
 function Subscription:notify(args)
 	if not self.listenerFn then
-		error("Subscription is closed")
-	end
+        error("Subscription is closed")
+    end
 
-	return pcall(function()
-		return self.listenerFn(unpack2(args))
-	end)
+    local ok, result = xpcall(
+        function()
+            return self.listenerFn(unpack2(args))
+        end,
+        function(e)
+            -- Capture and return the stack trace of the xpcall
+			-- 2 makes it start a frame higher so it doesn't include
+			-- this error handling fn
+            return debug.traceback(tostring(e), 2)
+        end
+    )
+
+    return ok, result
 end
+
 
 --- Unsubscribes this Subscription the next time the event passed in argument
 --- is triggered.
@@ -213,10 +224,29 @@ local function isStackOverflowError(err)
 	return string.find(err, "C stack overflow")
 end
 
-local function buildErrorMessage(headerMessage, subscriptionCaller, dispatchCaller)
+local function splitTrace(trace)
+    local firstLine, rest = trace:match("([^\n]+)\n?(.*)")
+    return firstLine, rest
+end
+
+local function stripAfterXpcall(trace)
+    local out = {}
+    for line in trace:gmatch("[^\n]+") do
+        if line:find("%[C%]: in function 'xpcall'") then
+            break
+        end
+        out[#out+1] = line
+    end
+    return table.concat(out, "\n")
+end
+
+local function buildErrorMessage(headerMessage, errorOrResult, subscriptionCaller, dispatchCaller)
+	local firstLine, rest = splitTrace(errorOrResult)
 	return string.format(
-			"%s\n- Subscribed at: %s\n- Dispatched at: %s",
+			"%s%s\n- Call trace: \n    %s\n- Subscribed at: %s\n- Dispatched at: %s",
 			headerMessage,
+			firstLine,
+			string.gsub(stripAfterXpcall(rest), "\n", "\n    "),
 			string.gsub(subscriptionCaller, "\n", "\n    "),
 			string.gsub(dispatchCaller, "\n", "\n    ")
 	)
@@ -236,7 +266,7 @@ function Event:dispatch(...)
 		local ok, errorOrResult = sub:notify(args)
 
 		if not ok and errorOrResult then
-			local message = buildErrorMessage("An event callback failed: " .. errorOrResult, sub.creator, caller)
+			local message = buildErrorMessage("An event callback failed: ", errorOrResult, sub.creator, caller)
 			if isStackOverflowError(errorOrResult) then
 				error(message)
 			else

--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -16,132 +16,145 @@ modApi.events = {}
 setmetatable(modApi.events, events_mt)
 
 local t = modApi.events
-t.onModMetadataDone = Event()
-t.onModsMetadataDone = Event()
-t.onModInitialized = Event()
-t.onModsInitialized = Event()
-t.onModLoaded = Event()
-t.onModsLoaded = Event()
-t.onModsFirstLoaded = Event()
-t.onInitialLoadingFinished = Event()
-t.onFtldatFinalized = Event()
-t.onModContentReset = Event()
-t.onTestsuitesCreated = Event()
-
-t.onBoardClassInitialized = Event()
-t.onPawnClassInitialized = Event()
-t.onGameClassInitialized = Event()
-
-t.onUiRootCreating = Event()
-t.onUiRootCreated = Event()
-t.onGameWindowResized = Event()
-t.onConsoleToggled = Event()
-t.onFrameDrawStart = Event()
-t.onFrameDrawn = Event()
-t.onWindowVisible = Event()
-
-t.onMainMenuEntered = Event()
-t.onMainMenuExited = Event()
-t.onMainMenuLeaving = Event()
-t.onHangarEntered = Event()
-t.onHangarExited = Event()
-t.onHangarLeaving = Event()
-t.onHangarMechsSelected = Event()
-t.onHangarMechsCleared = Event()
-t.onHangarSquadSelected = Event()
-t.onHangarSquadCleared = Event()
-t.onGameEntered = Event()
-t.onGameExited = Event()
-t.onNewGameClicked = Event()
-t.onContinueClicked = Event()
-t.onSettingsChanged = Event()
-t.onSettingsInitialized = Event()
-t.onProfileChanged = Event()
-t.onProfileCreated = Event()
-t.onProfileDeleted = Event()
-t.onDifficultyChanged = Event()
-t.onLanguageChanged = Event()
-
-t.onHangarUiShown = Event()
-t.onHangarUiHidden = Event()
-t.onEscapeMenuWindowShown = Event()
-t.onEscapeMenuWindowHidden = Event()
-t.onSquadSelectionWindowShown = Event()
+modApi.eventNames = {
+	"onModMetadataDone",
+	"onModsMetadataDone",
+	"onModInitialized",
+	"onModsInitialized",
+	"onModLoaded",
+	"onModsLoaded",
+	"onModsFirstLoaded",
+	"onInitialLoadingFinished",
+	"onFtldatFinalized",
+	"onModContentReset",
+	"onTestsuitesCreated",
+	
+	"onBoardClassInitialized",
+	"onPawnClassInitialized",
+	"onGameClassInitialized",
+	
+	"onUiRootCreating",
+	"onUiRootCreated",
+	"onGameWindowResized",
+	"onConsoleToggled",
+	"onFrameDrawStart",
+	"onFrameDrawn",
+	"onWindowVisible",
+	
+	"onMainMenuEntered",
+	"onMainMenuExited",
+	"onMainMenuLeaving",
+	"onHangarEntered",
+	"onHangarExited",
+	"onHangarLeaving",
+	"onHangarMechsSelected",
+	"onHangarMechsCleared",
+	"onHangarSquadSelected",
+	"onHangarSquadCleared",
+	"onGameEntered",
+	"onGameExited",
+	"onNewGameClicked",
+	"onContinueClicked",
+	"onSettingsChanged",
+	"onSettingsInitialized",
+	"onProfileChanged",
+	"onProfileCreated",
+	"onProfileDeleted",
+	"onDifficultyChanged",
+	"onLanguageChanged",
+	
+	"onHangarUiShown",
+	"onHangarUiHidden",
+	"onEscapeMenuWindowShown",
+	"onEscapeMenuWindowHidden",
+	"onSquadSelectionWindowShown",
 -- arguments: newPage, lastPage, wasOpen
-t.onSquadSelectionPageChanged = Event()
-t.onSquadSelectionWindowHidden = Event()
-t.onCustomizeSquadWindowShown = Event()
-t.onCustomizeSquadWindowHidden = Event()
-t.onPilotSelectionWindowShown = Event()
-t.onPilotSelectionWindowHidden = Event()
-t.onDifficultySettingsWindowShown = Event()
-t.onDifficultySettingsWindowHidden = Event()
-t.onMechColorWindowShown = Event()
-t.onMechColorWindowHidden = Event()
-t.onAchievementsWindowShown = Event()
-t.onAchievementsWindowHidden = Event()
-t.onOptionsWindowShown = Event()
-t.onOptionsWindowHidden = Event()
-t.onLanguageSelectionWindowShown = Event()
-t.onLanguageSelectionWindowHidden = Event()
-t.onHotkeyConfigurationWindowShown = Event()
-t.onHotkeyConfigurationWindowHidden = Event()
-t.onProfileSelectionWindowShown = Event()
-t.onProfileSelectionWindowHidden = Event()
-t.onCreateProfileConfirmationWindowShown = Event()
-t.onCreateProfileConfirmationWindowHidden = Event()
-t.onDeleteProfileConfirmationWindowShown = Event()
-t.onDeleteProfileConfirmationWindowHidden = Event()
-t.onStatisticsWindowShown = Event()
-t.onStatisticsWindowHidden = Event()
-t.onNewGameWindowShown = Event()
-t.onNewGameWindowHidden = Event()
-t.onAbandonTimelineWindowShown = Event()
-t.onAbandonTimelineWindowHidden = Event()
-t.onStatusTooltipWindowShown = Event()
-t.onStatusTooltipWindowHidden = Event()
-t.onMapEditorTestEntered = Event()
-t.onMapEditorTestExited = Event()
-t.onPodWindowShown = Event()
-t.onPodWindowHidden = Event()
-t.onPerfectIslandWindowShown = Event()
-t.onPerfectIslandWindowHidden = Event()
-t.onWindowShown = Event()
-t.onWindowHidden = Event()
+	"onSquadSelectionPageChanged",
+	"onSquadSelectionWindowHidden",
+	"onCustomizeSquadWindowShown",
+	"onCustomizeSquadWindowHidden",
+	"onPilotSelectionWindowShown",
+	"onPilotSelectionWindowHidden",
+	"onDifficultySettingsWindowShown",
+	"onDifficultySettingsWindowHidden",
+	"onMechColorWindowShown",
+	"onMechColorWindowHidden",
+	"onAchievementsWindowShown",
+	"onAchievementsWindowHidden",
+	"onOptionsWindowShown",
+	"onOptionsWindowHidden",
+	"onLanguageSelectionWindowShown",
+	"onLanguageSelectionWindowHidden",
+	"onHotkeyConfigurationWindowShown",
+	"onHotkeyConfigurationWindowHidden",
+	"onProfileSelectionWindowShown",
+	"onProfileSelectionWindowHidden",
+	"onCreateProfileConfirmationWindowShown",
+	"onCreateProfileConfirmationWindowHidden",
+	"onDeleteProfileConfirmationWindowShown",
+	"onDeleteProfileConfirmationWindowHidden",
+	"onStatisticsWindowShown",
+	"onStatisticsWindowHidden",
+	"onNewGameWindowShown",
+	"onNewGameWindowHidden",
+	"onAbandonTimelineWindowShown",
+	"onAbandonTimelineWindowHidden",
+	"onStatusTooltipWindowShown",
+	"onStatusTooltipWindowHidden",
+	"onMapEditorTestEntered",
+	"onMapEditorTestExited",
+	"onPodWindowShown",
+	"onPodWindowHidden",
+	"onPerfectIslandWindowShown",
+	"onPerfectIslandWindowHidden",
+	"onWindowShown",
+	"onWindowHidden",
+	
+	"onMissionChanged",
+	"onMissionDismissed",
+	"onIslandLeft",
+	"onGameStateChanged",
+	"onGameVictory",
+	"onSquadEnteredGame",
+	"onSquadExitedGame",
+	"onTilesetChanged",
+	"onFinalIslandHighlighted",
+	"onFinalIslandUnhighlighted",
+	"onFinalIslandSelected",
+	"onFinalIslandDeselected",
+	
+	"onDeploymentPhaseStart",
+	"onLandingPhaseStart",
+	"onDeploymentPhaseEnd",
+	"onPawnUnselectedForDeployment",
+	"onPawnSelectedForDeployment",
+	"onPawnDeployed",
+	"onPawnUndeployed",
+	"onPawnLanding",
+	"onPawnLanded",
+	
+	"onBoardAddEffect",
+	"onBoardDamageSpace",
+	
+	"onShiftToggled",
+	"onAltToggled",
+	"onCtrlToggled",
+}
 
-t.onMissionChanged = Event()
-t.onMissionDismissed = Event()
-t.onIslandLeft = Event()
-t.onGameStateChanged = Event()
-t.onGameVictory = Event()
-t.onSquadEnteredGame = Event()
-t.onSquadExitedGame = Event()
-t.onTilesetChanged = Event()
-t.onFinalIslandHighlighted = Event()
-t.onFinalIslandUnhighlighted = Event()
-t.onFinalIslandSelected = Event()
-t.onFinalIslandDeselected = Event()
+for _, event in ipairs(modApi.eventNames) do
+	t[event] = Event({ eventName = event })
+end
 
-t.onDeploymentPhaseStart = Event()
-t.onLandingPhaseStart = Event()
-t.onDeploymentPhaseEnd = Event()
-t.onPawnUnselectedForDeployment = Event()
-t.onPawnSelectedForDeployment = Event()
-t.onPawnDeployed = Event()
-t.onPawnUndeployed = Event()
-t.onPawnLanding = Event()
-t.onPawnLanded = Event()
+modApi.shortcutEventNames = {
+	"onKeyPressing",
+	"onKeyPressed",
+	"onKeyReleasing",
+	"onKeyReleased",
+}
 
-t.onBoardAddEffect = Event()
-t.onBoardDamageSpace = Event()
-
-t.onShiftToggled = Event()
-t.onAltToggled = Event()
-t.onCtrlToggled = Event()
-t.onKeyPressing = Event({ [Event.SHORTCIRCUIT] = true })
-t.onKeyPressed = Event({ [Event.SHORTCIRCUIT] = true })
-t.onKeyReleasing = Event({ [Event.SHORTCIRCUIT] = true })
-t.onKeyReleased = Event({ [Event.SHORTCIRCUIT] = true })
+for _, event in ipairs(modApi.shortcutEventNames) do
+	t[event] = Event({ eventName = event, [Event.SHORTCIRCUIT] = true })
+end
 
 -- //////////////////////////////////////////////////////////////////////////////
 -- Hooks


### PR DESCRIPTION
This makes debugging why your callback failed much easier especially if you are using other peoples libs/code

Below is an example of an intentionally injected hook and event failure. Before it only included the line it failed on instead of teh call trace section. Additionally it did not have the event\hook field before. This should allow for easier debugging of hooks especially that are failing in lower level, generic code
```
[2026-02-02 22:01:01] [./scripts/mod_loader/bootstrap/event.lua:282]: An event callback failed: ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:19: attempt to index global 'varToFailOn' (a nil value)
- Event\Hook: onGameEntered
- Call trace: 
    stack traceback:
        ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:19: in function 'testFnEventFailure3'
        ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:23: in function 'testFnEventFailure2'
        ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:27: in function 'testFnEventFailure1'
        ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:56: in function <...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:55>
        (tail call): ?
- Subscribed at: 
    stack traceback:
        ./scripts/mod_loader/bootstrap/event.lua:140: in function 'subscribe'
        ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:55: in function 'init'
        ...ns/RedactedRiceExts/exts/CPLUS+_Ex/cplus_plus_ex.lua:77: in function 'initModules'
        ...ns/RedactedRiceExts/exts/CPLUS+_Ex/cplus_plus_ex.lua:135: in function 'init'
        ...ons/RedactedRiceExts/exts/CPLUS+_Ex/scripts/init.lua:25: in function 'init'
        ./scripts/mod_loader/mod_loader.lua:464: in function <./scripts/mod_loader/mod_loader.lua:462>
        [C]: in function 'xpcall'
        ./scripts/mod_loader/mod_loader.lua:461: in function 'initMod'
        ./scripts/mod_loader/mod_loader.lua:157: in function 'init'
        ./scripts/mod_loader/mod_loader.lua:781: in main chunk
        [C]: in function 'require'
        ./scripts/mod_loader/__scripts.lua:42: in main chunk
        [C]: in function 'require'
        scripts/modloader.lua:1: in main chunk
- Dispatched at: 
    stack traceback:
        ./scripts/mod_loader/bootstrap/event.lua:294: in function 'dispatch'
        ./scripts/mod_loader/modui/root.lua:288: in function <./scripts/mod_loader/modui/root.lua:226>
```
```
[2026-02-02 22:04:33] [./scripts/mod_loader/bootstrap/event.lua:282]: An event callback failed: ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:31: attempt to index global 'varToFailOn' (a nil value)
- Event\Hook: fireNextTurnHooks
- Call trace: 
    stack traceback:
        ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:31: in function 'testFnHookFailure3'
        ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:35: in function 'testFnHookFailure2'
        ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:39: in function 'testFnHookFailure1'
        ...tedRiceExts/exts/CPLUS+_Ex/scripts/time_traveler.lua:78: in function 'fn'
        ./scripts/mod_loader/bootstrap/modApi.lua:186: in function <./scripts/mod_loader/bootstrap/modApi.lua:184>
        (tail call): ?
- Subscribed at: 
    stack traceback:
        ./scripts/mod_loader/bootstrap/event.lua:140: in function 'subscribe'
        ./scripts/mod_loader/bootstrap/modApi.lua:184: in function 'AddHook'
        ./scripts/mod_loader/bootstrap/modApi.lua:235: in main chunk
        [C]: in function 'require'
        ./scripts/mod_loader/bootstrap/__scripts.lua:18: in main chunk
        [C]: in function 'require'
        ./scripts/mod_loader/__scripts.lua:42: in main chunk
        [C]: in function 'require'
        scripts/modloader.lua:1: in main chunk
- Dispatched at: 
    stack traceback:
        ./scripts/mod_loader/bootstrap/event.lua:294: in function 'dispatch'
        ./scripts/mod_loader/bootstrap/modApi.lua:181: in function 'fireNextTurnHooks'
        ./scripts/mod_loader/altered/missions.lua:57: in function <./scripts/mod_loader/altered/missions.lua:45>
        (tail call): ?		
```

------

To test, add code that will intentionally fail and trigger the hooks. In this case, I added an addNextTurnHook hook and a onGameEntered event (~~each only had the hook/event which is why they are different hook/event~~ TActually it seems there is an event for every hook but this works anyways) with a few layers of fns just to show the stack trace is working correctly
```
local function testFnEventFailure3()
	varToFailOn.nilObj = 5
end

local function testFnEventFailure2()
	testFnEventFailure3()
end

local function testFnEventFailure1()
	testFnEventFailure2()
end

local function testFnHookFailure3()
	varToFailOn.nilObj = 5
end

local function testFnHookFailure2()
	testFnHookFailure3()
end

local function testFnHookFailure1()
	testFnHookFailure2()
end

mod:init()
	modApi.events.onGameEntered:subscribe(function()
		testFnEventFailure1()
	end)
end
mod:load()
	modApi:addNextTurnHook(function()
		testFnHookFailure1()
	end)
end
```

Then start a game (trigger onGameEntered failure), enter a mission and end turn (trigger nextTurnHook)