### PR TITLE
Adding event for store window being visible

### DIFF
--- a/scripts/mod_loader/bootstrap/modApi.lua
+++ b/scripts/mod_loader/bootstrap/modApi.lua
@@ -106,6 +106,8 @@ t.onPodWindowShown = Event()
 t.onPodWindowHidden = Event()
 t.onPerfectIslandWindowShown = Event()
 t.onPerfectIslandWindowHidden = Event()
+t.onStoreWindowShown = Event()
+t.onStoreWindowHidden = Event()
 t.onWindowShown = Event()
 t.onWindowHidden = Event()
 

--- a/scripts/mod_loader/modui/windows.lua
+++ b/scripts/mod_loader/modui/windows.lua
@@ -163,6 +163,11 @@ local windows = {
 		event_hide = modApi.events.onPerfectIslandWindowHidden,
 		find_rect = getRectFromShadowSurfaces
 	},
+	Store_SellTitle = Window:new{
+		event_show = modApi.events.onStoreWindowShown,
+		event_hide = modApi.events.onStoreWindowHidden,
+		find_rect = getRectFromShadowSurfaces
+	},
 	Button_Editor_Exit = Window:new{
 		event_show = modApi.events.onMapEditorTestEntered,
 		event_hide = modApi.events.onMapEditorTestExited,
@@ -190,6 +195,7 @@ sdlext.isAbandonTimelineWindowVisible = buildIsWindowVisibleFunction(windows.Aba
 sdlext.isStatusTooltipWindowVisible = buildIsWindowVisibleFunction(windows.Unit_Status_Title)
 sdlext.isPodWindowVisible = buildIsWindowVisibleFunction(windows.Pod_Title)
 sdlext.isPerfectIslandWindowVisible = buildIsWindowVisibleFunction(windows.Reward_Title)
+sdlext.isStoreWindowVisible = buildIsWindowVisibleFunction(windows.Store_SellTitle)
 sdlext.isMapEditor = buildIsWindowVisibleFunction(windows.Button_Editor_Exit)
 
 -- gets the current page on the squad selection page, or nil if on none

--- a/scripts/mod_loader/modui/windows.lua
+++ b/scripts/mod_loader/modui/windows.lua
@@ -161,6 +161,11 @@ local windows = {
 		event_hide = modApi.events.onPerfectIslandWindowHidden,
 		find_rect = getRectFromShadowSurfaces
 	},
+	Store_SellTitle = Window:new{
+		event_show = modApi.events.onStoreWindowShown,
+		event_hide = modApi.events.onStoreWindowHidden,
+		find_rect = getRectFromShadowSurfaces
+	},
 	Button_Editor_Exit = Window:new{
 		event_show = modApi.events.onMapEditorTestEntered,
 		event_hide = modApi.events.onMapEditorTestExited,
@@ -196,6 +201,7 @@ sdlext.isAbandonTimelineWindowVisible = buildIsWindowVisibleFunction(windows.Aba
 sdlext.isStatusTooltipWindowVisible = buildIsWindowVisibleFunction(windows.Unit_Status_Title)
 sdlext.isPodWindowVisible = buildIsWindowVisibleFunction(windows.Pod_Title)
 sdlext.isPerfectIslandWindowVisible = buildIsWindowVisibleFunction(windows.Reward_Title)
+sdlext.isStoreWindowVisible = buildIsWindowVisibleFunction(windows.Store_SellTitle)
 sdlext.isMapEditor = buildIsWindowVisibleFunction(windows.Button_Editor_Exit)
 
 -- gets the current page on the squad selection page, or nil if on none


### PR DESCRIPTION
Adding events for when the store is opened. Same changes as done in https://github.com/itb-community/ITB-ModLoader/pull/229 for additional UIs

Can be tested by adding logging hooks for the added events by pasting the code below into the console and then triggering them in game (via `store` console command)

	modApi.events.onStoreWindowShown:subscribe(function()
		LOG("STORE SHOWN!!!")
	end)
	modApi.events.onStoreWindowHidden:subscribe(function()
		LOG("STORE HIDDEN!!!")
	end)